### PR TITLE
fix: Add default on success timeout

### DIFF
--- a/pkg/keboola/api_config.go
+++ b/pkg/keboola/api_config.go
@@ -19,7 +19,9 @@ type apiConfig struct {
 type APIOption func(c *apiConfig)
 
 func newAPIConfig(opts []APIOption) apiConfig {
-	cfg := apiConfig{}
+	cfg := apiConfig{
+		onSuccessTimeout: time.Minute,
+	}
 	for _, opt := range opts {
 		opt(&cfg)
 	}


### PR DESCRIPTION
**Changes:**
- The on success timeout is needed for some API calls and should be set to some default value.
- It is prepend to the slice so it can be override by other settings

-----------
