### PR TITLE
PAT-328: Add `Event.RunID` field

### DIFF
--- a/pkg/keboola/storage_events.go
+++ b/pkg/keboola/storage_events.go
@@ -23,6 +23,7 @@ type Event struct {
 	Duration    client.DurationSeconds `json:"duration"`
 	Params      JSONString             `json:"params"`
 	Results     JSONString             `json:"results"`
+	RunID       string                 `json:"runId"`
 }
 
 // CreateEventRequest https://keboola.docs.apiary.io/#reference/events/events/create-event

--- a/pkg/keboola/storage_events_test.go
+++ b/pkg/keboola/storage_events_test.go
@@ -22,6 +22,7 @@ func TestSendEvent(t *testing.T) {
 		Params:      map[string]any{"command": "bar1"},
 		Results:     map[string]any{"projectId": 123, "error": "err"},
 		Duration:    client.DurationSeconds(123456 * time.Millisecond),
+		RunID:       "123",
 	}).Send(ctx)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, event.ID)


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/PAT-328

**Changes:**
- add missing `RunID` field to `Event` struct in `pkg/keboola/storage_events.go`

-----------
