### PR TITLE
feat(workspaces): extend workspace table export to BigQuery

### DIFF
--- a/pkg/keboola/storage_workspace_table_export.go
+++ b/pkg/keboola/storage_workspace_table_export.go
@@ -11,7 +11,6 @@ import (
 
 // WorkspaceTableExportRequestBuilder builds requests for exporting tables from workspaces.
 // This operation exports existing tables from a workspace to a file in the storage backend.
-// Currently, only Snowflake backend is supported.
 type WorkspaceTableExportRequestBuilder struct {
 	branchID    BranchID
 	workspaceID uint64

--- a/pkg/keboola/storage_workspace_table_export_test.go
+++ b/pkg/keboola/storage_workspace_table_export_test.go
@@ -2,7 +2,6 @@ package keboola_test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -16,98 +15,97 @@ import (
 // as it requires transfer.Upload.
 
 func TestWorkspaceTableExport(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 	ctx := t.Context()
 	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithSnowflakeBackend())
 
-	ctx, cancelFn := context.WithTimeout(ctx, time.Second*30)
+	ctx, cancelFn := context.WithTimeout(ctx, 5*time.Minute)
 	t.Cleanup(cancelFn)
 
-	// Get default branch
 	defBranch, err := api.GetDefaultBranchRequest().Send(ctx)
 	require.NoError(t, err)
 
-	// Create workspace
-	networkPolicy := "user"
-	workspace := &keboola.StorageWorkspacePayload{
-		Backend:       keboola.StorageWorkspaceBackendSnowflake,
-		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
-		NetworkPolicy: &networkPolicy,
-		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
-	}
-
-	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)
+	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
+		Backend:   keboola.StorageWorkspaceBackendSnowflake,
+		LoginType: keboola.StorageWorkspaceLoginTypeDefault,
+	}).Send(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, createdWorkspace)
 
-	// Ensure workspace is cleaned up even if test fails
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cleanupCancel()
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 		_, _ = api.StorageWorkspaceDeleteRequest(defBranch.ID, createdWorkspace.ID).Send(cleanupCtx)
 	})
 
-	// Test the workspace table export functionality
-	// Note: A full end-to-end test would require:
-	// 1. Creating a workspace (done above)
-	// 2. Loading a Storage table into the workspace
-	// 3. Exporting the table from the workspace
-	// 4. Verifying the exported file
-	//
-	// Since workspace data loading is complex and may not be implemented in all backends,
-	// these tests focus on verifying the API structure and error handling.
+	runWorkspaceTableExportSubtests(t, ctx, api, defBranch.ID, createdWorkspace.ID)
+}
+
+func TestWorkspaceTableExportBigQuery(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithBigQueryBackend())
+
+	ctx, cancelFn := context.WithTimeout(ctx, 5*time.Minute)
+	t.Cleanup(cancelFn)
+
+	defBranch, err := api.GetDefaultBranchRequest().Send(ctx)
+	require.NoError(t, err)
+
+	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
+		Backend:   keboola.StorageWorkspaceBackendBigQuery,
+		LoginType: keboola.StorageWorkspaceLoginTypeDefault,
+	}).Send(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, createdWorkspace)
+
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, _ = api.StorageWorkspaceDeleteRequest(defBranch.ID, createdWorkspace.ID).Send(cleanupCtx)
+	})
+
+	runWorkspaceTableExportSubtests(t, ctx, api, defBranch.ID, createdWorkspace.ID)
+}
+
+// runWorkspaceTableExportSubtests runs error-path subtests that work for any backend.
+// SendRequestWithAllOptions is intentionally omitted: Snowflake rejects synchronously while
+// BigQuery queues the job and only fails on wait — SendAndWait covers that case for both.
+func runWorkspaceTableExportSubtests(t *testing.T, ctx context.Context, api *keboola.AuthorizedAPI, branchID keboola.BranchID, workspaceID uint64) {
+	t.Helper()
 
 	t.Run("BuildRequest", func(t *testing.T) {
 		t.Parallel()
-		// Test building the request without sending
-		req := api.NewWorkspaceTableExportRequest(defBranch.ID, createdWorkspace.ID, "test_table").
+		req := api.NewWorkspaceTableExportRequest(branchID, workspaceID, "test_table").
 			WithFileName("exported_table.csv").
 			WithFileType("csv").
 			WithGzip(true).
 			Build()
-
 		require.NotNil(t, req)
-	})
-
-	t.Run("SendRequestWithAllOptions", func(t *testing.T) {
-		t.Parallel()
-		// Test sending a request with all options
-		// This will fail because the table doesn't exist in the workspace
-		_, err := api.NewWorkspaceTableExportRequest(defBranch.ID, createdWorkspace.ID, "test_table").
-			WithFileName("exported_table.csv").
-			WithFileType("csv").
-			Send(ctx)
-		require.Error(t, err)
 	})
 
 	t.Run("SendRequestMinimal", func(t *testing.T) {
 		t.Parallel()
-		// Test sending a minimal request with only required parameters
-		// This will fail because the table doesn't exist in the workspace
-		_, err := api.NewWorkspaceTableExportRequest(defBranch.ID, createdWorkspace.ID, "test_table").
+		_, err := api.NewWorkspaceTableExportRequest(branchID, workspaceID, "test_table").
 			Send(ctx)
 		require.Error(t, err)
 	})
 
 	t.Run("SendAndWait", func(t *testing.T) {
 		t.Parallel()
-		// Test SendAndWait method
-		// This will fail because the table doesn't exist in the workspace
-		_, err := api.NewWorkspaceTableExportRequest(defBranch.ID, createdWorkspace.ID, "test_table").
+		_, err := api.NewWorkspaceTableExportRequest(branchID, workspaceID, "test_table").
 			WithFileName("exported_table.csv").
 			WithFileType("csv").
-			SendAndWait(ctx, time.Minute*2)
+			SendAndWait(ctx, 2*time.Minute)
 		require.Error(t, err)
 	})
 
 	t.Run("Format does not match", func(t *testing.T) {
 		t.Parallel()
-		_, err := api.NewWorkspaceTableExportRequest(defBranch.ID, createdWorkspace.ID, "test_table").
+		_, err := api.NewWorkspaceTableExportRequest(branchID, workspaceID, "test_table").
 			WithFileName("exported_table.csv").
 			WithFileType("fake_format").
-			SendAndWait(ctx, time.Minute*2)
+			SendAndWait(ctx, 2*time.Minute)
 		require.Error(t, err)
 	})
 }

--- a/v2/transfer/storage_workspace_export_test.go
+++ b/v2/transfer/storage_workspace_export_test.go
@@ -16,9 +16,8 @@ import (
 	"github.com/keboola/keboola-sdk-go/v2/transfer"
 )
 
-// TestWorkspaceTableExportSuccess tests the successful export of a table from workspace.
+// TestWorkspaceTableExportSuccess tests the successful export of a table from a Snowflake workspace.
 func TestWorkspaceTableExportSuccess(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 	ctx := t.Context()
 	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithSnowflakeBackend())
@@ -26,47 +25,34 @@ func TestWorkspaceTableExportSuccess(t *testing.T) {
 	ctx, cancelFn := context.WithTimeout(ctx, time.Minute*10)
 	t.Cleanup(cancelFn)
 
-	// Get default branch
 	defBranch, err := api.GetDefaultBranchRequest().Send(ctx)
 	require.NoError(t, err)
 
-	// Create bucket and table in Storage
 	bucket, tableKey := createBucketAndTableKey(defBranch)
 	_, err = api.CreateBucketRequest(bucket).Send(ctx)
 	require.NoError(t, err)
 
-	// Create file with test data
-	fileName := "test_data.csv"
-	file, err := api.CreateFileResourceRequest(defBranch.ID, fileName).Send(ctx)
+	file, err := api.CreateFileResourceRequest(defBranch.ID, "test_data.csv").Send(ctx)
 	require.NoError(t, err)
 
-	// Upload file with test data
-	content := []byte("col1,col2\nval1,val2\nval3,val4\n")
-	_, err = transfer.Upload(ctx, file, bytes.NewReader(content))
+	_, err = transfer.Upload(ctx, file, bytes.NewReader([]byte("col1,col2\nval1,val2\nval3,val4\n")))
 	require.NoError(t, err)
 
-	// Create table from file
 	_, err = api.CreateTableFromFileRequest(tableKey, file.FileKey).Send(ctx)
 	require.NoError(t, err)
 
-	// Create workspace
 	networkPolicy := "user"
-	workspace := &keboola.StorageWorkspacePayload{
+	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
 		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
 		PublicKey:     new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
-	}
-
-	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)
+	}).Send(ctx)
 	require.NoError(t, err)
-	require.NotNil(t, createdWorkspace)
-
-	// Ensure workspace is cleaned up even if test fails
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cleanupCancel()
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 		_, _ = api.StorageWorkspaceDeleteRequest(defBranch.ID, createdWorkspace.ID).Send(cleanupCtx)
 	})
 
@@ -74,50 +60,77 @@ func TestWorkspaceTableExportSuccess(t *testing.T) {
 	assert.Equal(t, keboola.StorageWorkspaceBackendSizeMedium, *createdWorkspace.BackendSize)
 	assert.Equal(t, string(keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair), *createdWorkspace.StorageWorkspaceDetails.LoginType)
 
-	// Load data into workspace
-	loadPayload := &keboola.WorkspaceLoadDataPayload{
-		Input: []keboola.WorkspaceLoadDataInput{
-			{
-				Source:      tableKey.TableID.String(),
-				Destination: "test_table",
-			},
-		},
-	}
+	loadTableIntoWorkspace(t, ctx, api, defBranch.ID, createdWorkspace.ID, tableKey)
 
-	job, err := api.StorageWorkspaceLoadDataRequest(defBranch.ID, createdWorkspace.ID, loadPayload).Send(ctx)
-	require.NoError(t, err)
-
-	// Wait for load job to complete
-	waitCtx1, waitCancelFn1 := context.WithTimeout(ctx, time.Minute*5)
-	t.Cleanup(waitCancelFn1)
-	err = api.WaitForStorageJob(waitCtx1, job)
-	require.NoError(t, err)
-	assert.Equal(t, "success", job.Status)
-
-	// Export the table from workspace
 	result, err := api.NewWorkspaceTableExportRequest(defBranch.ID, createdWorkspace.ID, "test_table").
 		WithFileName("test_export.csv").
 		WithFileType("csv").
 		SendAndWait(ctx, time.Second*30)
-
-	// Verify successful export
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotZero(t, result.File.FileID)
 
-	// Verify the exported file exists in Storage
-	fileKey := keboola.FileKey{
-		BranchID: defBranch.ID,
-		FileID:   result.File.FileID,
-	}
-	file2, err := api.GetFileRequest(fileKey).Send(ctx)
+	file2, err := api.GetFileRequest(keboola.FileKey{BranchID: defBranch.ID, FileID: result.File.FileID}).Send(ctx)
 	require.NoError(t, err)
-	require.NotNil(t, file2)
 	require.Equal(t, result.File.FileID, file2.FileID)
 	require.Equal(t, defBranch.ID, file2.BranchID)
 }
 
-// TestWorkspaceTableExportGzip tests that WithGzip option controls whether the exported file is gzip-compressed.
+// TestWorkspaceTableExportSuccessBigQuery tests the successful export of a table from a BigQuery workspace.
+func TestWorkspaceTableExportSuccessBigQuery(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithBigQueryBackend())
+
+	ctx, cancelFn := context.WithTimeout(ctx, time.Minute*10)
+	t.Cleanup(cancelFn)
+
+	defBranch, err := api.GetDefaultBranchRequest().Send(ctx)
+	require.NoError(t, err)
+
+	bucket, tableKey := createBucketAndTableKey(defBranch)
+	_, err = api.CreateBucketRequest(bucket).Send(ctx)
+	require.NoError(t, err)
+
+	file, err := api.CreateFileResourceRequest(defBranch.ID, "test_data.csv").Send(ctx)
+	require.NoError(t, err)
+
+	_, err = transfer.Upload(ctx, file, bytes.NewReader([]byte("col1,col2\nval1,val2\nval3,val4\n")))
+	require.NoError(t, err)
+
+	_, err = api.CreateTableFromFileRequest(tableKey, file.FileKey).Send(ctx)
+	require.NoError(t, err)
+
+	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
+		Backend:   keboola.StorageWorkspaceBackendBigQuery,
+		LoginType: keboola.StorageWorkspaceLoginTypeDefault,
+	}).Send(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, _ = api.StorageWorkspaceDeleteRequest(defBranch.ID, createdWorkspace.ID).Send(cleanupCtx)
+	})
+
+	assert.Equal(t, keboola.StorageWorkspaceBackendBigQuery, createdWorkspace.StorageWorkspaceDetails.Backend)
+
+	loadTableIntoWorkspace(t, ctx, api, defBranch.ID, createdWorkspace.ID, tableKey)
+
+	result, err := api.NewWorkspaceTableExportRequest(defBranch.ID, createdWorkspace.ID, "test_table").
+		WithFileName("test_export.csv").
+		WithFileType("csv").
+		SendAndWait(ctx, time.Second*30)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotZero(t, result.File.FileID)
+
+	file2, err := api.GetFileRequest(keboola.FileKey{BranchID: defBranch.ID, FileID: result.File.FileID}).Send(ctx)
+	require.NoError(t, err)
+	require.Equal(t, result.File.FileID, file2.FileID)
+	require.Equal(t, defBranch.ID, file2.BranchID)
+}
+
+// TestWorkspaceTableExportGzip tests that WithGzip controls compression for a Snowflake workspace export.
 func TestWorkspaceTableExportGzip(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -126,85 +139,112 @@ func TestWorkspaceTableExportGzip(t *testing.T) {
 	ctx, cancelFn := context.WithTimeout(ctx, time.Minute*10)
 	t.Cleanup(cancelFn)
 
-	// Get default branch
 	defBranch, err := api.GetDefaultBranchRequest().Send(ctx)
 	require.NoError(t, err)
 
-	// Create bucket and table in Storage
 	bucket, tableKey := createBucketAndTableKey(defBranch)
 	_, err = api.CreateBucketRequest(bucket).Send(ctx)
 	require.NoError(t, err)
 
-	// Create file with test data
-	fileName := "test_data_gzip.csv"
-	file, err := api.CreateFileResourceRequest(defBranch.ID, fileName).Send(ctx)
+	file, err := api.CreateFileResourceRequest(defBranch.ID, "test_data_gzip.csv").Send(ctx)
 	require.NoError(t, err)
 
-	// Upload file with test data
-	content := []byte("col1,col2\nval1,val2\nval3,val4\n")
-	_, err = transfer.Upload(ctx, file, bytes.NewReader(content))
+	_, err = transfer.Upload(ctx, file, bytes.NewReader([]byte("col1,col2\nval1,val2\nval3,val4\n")))
 	require.NoError(t, err)
 
-	// Create table from file
 	_, err = api.CreateTableFromFileRequest(tableKey, file.FileKey).Send(ctx)
 	require.NoError(t, err)
 
-	// Create workspace
 	networkPolicy := "user"
-	workspace := &keboola.StorageWorkspacePayload{
+	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
 		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
 		PublicKey:     new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
-	}
-
-	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)
+	}).Send(ctx)
 	require.NoError(t, err)
-	require.NotNil(t, createdWorkspace)
-
-	// Ensure workspace is cleaned up even if test fails
 	t.Cleanup(func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cleanupCancel()
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 		_, _ = api.StorageWorkspaceDeleteRequest(defBranch.ID, createdWorkspace.ID).Send(cleanupCtx)
 	})
 
-	// Load data into workspace
-	loadPayload := &keboola.WorkspaceLoadDataPayload{
+	loadTableIntoWorkspace(t, ctx, api, defBranch.ID, createdWorkspace.ID, tableKey)
+
+	runGzipSubtests(t, ctx, api, defBranch, createdWorkspace.ID)
+}
+
+// TestWorkspaceTableExportGzipBigQuery tests that WithGzip controls compression for a BigQuery workspace export.
+func TestWorkspaceTableExportGzipBigQuery(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithBigQueryBackend())
+
+	ctx, cancelFn := context.WithTimeout(ctx, time.Minute*10)
+	t.Cleanup(cancelFn)
+
+	defBranch, err := api.GetDefaultBranchRequest().Send(ctx)
+	require.NoError(t, err)
+
+	bucket, tableKey := createBucketAndTableKey(defBranch)
+	_, err = api.CreateBucketRequest(bucket).Send(ctx)
+	require.NoError(t, err)
+
+	file, err := api.CreateFileResourceRequest(defBranch.ID, "test_data_gzip.csv").Send(ctx)
+	require.NoError(t, err)
+
+	_, err = transfer.Upload(ctx, file, bytes.NewReader([]byte("col1,col2\nval1,val2\nval3,val4\n")))
+	require.NoError(t, err)
+
+	_, err = api.CreateTableFromFileRequest(tableKey, file.FileKey).Send(ctx)
+	require.NoError(t, err)
+
+	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
+		Backend:   keboola.StorageWorkspaceBackendBigQuery,
+		LoginType: keboola.StorageWorkspaceLoginTypeDefault,
+	}).Send(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, _ = api.StorageWorkspaceDeleteRequest(defBranch.ID, createdWorkspace.ID).Send(cleanupCtx)
+	})
+
+	loadTableIntoWorkspace(t, ctx, api, defBranch.ID, createdWorkspace.ID, tableKey)
+
+	runGzipSubtests(t, ctx, api, defBranch, createdWorkspace.ID)
+}
+
+func loadTableIntoWorkspace(t *testing.T, ctx context.Context, api *keboola.AuthorizedAPI, branchID keboola.BranchID, workspaceID uint64, tableKey keboola.TableKey) {
+	t.Helper()
+	job, err := api.StorageWorkspaceLoadDataRequest(branchID, workspaceID, &keboola.WorkspaceLoadDataPayload{
 		Input: []keboola.WorkspaceLoadDataInput{
-			{
-				Source:      tableKey.TableID.String(),
-				Destination: "test_table",
-			},
+			{Source: tableKey.TableID.String(), Destination: "test_table"},
 		},
-	}
-
-	job, err := api.StorageWorkspaceLoadDataRequest(defBranch.ID, createdWorkspace.ID, loadPayload).Send(ctx)
+	}).Send(ctx)
 	require.NoError(t, err)
 
-	waitCtx1, waitCancelFn1 := context.WithTimeout(ctx, time.Minute*5)
-	t.Cleanup(waitCancelFn1)
-	err = api.WaitForStorageJob(waitCtx1, job)
-	require.NoError(t, err)
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	t.Cleanup(cancel)
+	require.NoError(t, api.WaitForStorageJob(waitCtx, job))
 	assert.Equal(t, "success", job.Status)
+}
 
-	// downloadExportedFile downloads the exported file raw bytes.
+func runGzipSubtests(t *testing.T, ctx context.Context, api *keboola.AuthorizedAPI, defBranch *keboola.Branch, workspaceID uint64) {
+	t.Helper()
+
 	downloadExportedFile := func(t *testing.T, fileID keboola.FileID) []byte {
 		t.Helper()
-		fileKey := keboola.FileKey{
-			BranchID: defBranch.ID,
-			FileID:   fileID,
-		}
-		fileCreds, err := api.GetFileWithCredentialsRequest(fileKey).Send(ctx)
+		fileCreds, err := api.GetFileWithCredentialsRequest(keboola.FileKey{BranchID: defBranch.ID, FileID: fileID}).Send(ctx)
 		require.NoError(t, err)
 
 		var rawData []byte
 		if fileCreds.IsSliced {
 			slices, sliceErr := transfer.DownloadManifest(ctx, fileCreds)
 			require.NoError(t, sliceErr)
-			for _, slice := range slices {
-				sliceData, dlErr := transfer.DownloadSlice(ctx, fileCreds, slice)
+			for _, s := range slices {
+				sliceData, dlErr := transfer.DownloadSlice(ctx, fileCreds, s)
 				require.NoError(t, dlErr)
 				rawData = append(rawData, sliceData...)
 			}
@@ -212,17 +252,16 @@ func TestWorkspaceTableExportGzip(t *testing.T) {
 			rawData, err = transfer.Download(ctx, fileCreds)
 			require.NoError(t, err)
 		}
-		require.NotEmpty(t, rawData, "exported file should not be empty")
+		require.NotEmpty(t, rawData)
 		return rawData
 	}
 
-	// Export WITHOUT gzip — data should not be valid gzip
 	t.Run("without_gzip", func(t *testing.T) {
 		t.Parallel()
-		result, err := api.NewWorkspaceTableExportRequest(defBranch.ID, createdWorkspace.ID, "test_table").
+		result, err := api.NewWorkspaceTableExportRequest(defBranch.ID, workspaceID, "test_table").
 			WithFileName("test_export_plain").
 			WithFileType("csv").
-			SendAndWait(ctx, time.Minute*2)
+			SendAndWait(ctx, 2*time.Minute)
 		require.NoError(t, err)
 		require.NotZero(t, result.File.FileID)
 
@@ -231,14 +270,13 @@ func TestWorkspaceTableExportGzip(t *testing.T) {
 		require.Error(t, gzErr, "exported file without gzip should not be valid gzip")
 	})
 
-	// Export WITH gzip — data should be valid gzip
 	t.Run("with_gzip", func(t *testing.T) {
 		t.Parallel()
-		result, err := api.NewWorkspaceTableExportRequest(defBranch.ID, createdWorkspace.ID, "test_table").
+		result, err := api.NewWorkspaceTableExportRequest(defBranch.ID, workspaceID, "test_table").
 			WithFileName("test_export_gzip.csv").
 			WithFileType("csv").
 			WithGzip(true).
-			SendAndWait(ctx, time.Minute*2)
+			SendAndWait(ctx, 2*time.Minute)
 		require.NoError(t, err)
 		require.NotZero(t, result.File.FileID)
 


### PR DESCRIPTION
**Changes:**
- Removes the "Snowflake-only" restriction from `WorkspaceTableExportRequestBuilder` — BigQuery workspace exports now work via the same API endpoint
- Unskips `TestWorkspaceTableExportSuccess` and `TestWorkspaceTableExport` (Snowflake unit test switched to `LoginTypeDefault` so it runs without a keypair env var)
- Adds `TestWorkspaceTableExportBigQuery` — unit error-path tests for BigQuery
- Adds `TestWorkspaceTableExportSuccessBigQuery` and `TestWorkspaceTableExportGzipBigQuery` — full end-to-end integration tests (create table → load into workspace → export → verify file/gzip)
- Extracts shared helpers `runWorkspaceTableExportSubtests`, `loadTableIntoWorkspace`, `runGzipSubtests` to avoid duplication between Snowflake and BigQuery variants

-----------