### PR TITLE
feat(management): add K8sAuth security scheme for X-Kubernetes-Authorization

### DIFF
--- a/pkg/keboola/management/README.md
+++ b/pkg/keboola/management/README.md
@@ -462,34 +462,13 @@ auth := context.WithValue(
 r, err := client.Service.Operation(auth, args)
 ```
 
-### K8sAuth
-
-- **Type**: API key
-- **API key parameter name**: X-Kubernetes-Authorization
-- **Location**: HTTP header
-
-Note, each API key must be added to a map of `map[string]APIKey` where the key is: K8sAuth and passed in as the auth context for each request.
-
-Example
-
-```go
-auth := context.WithValue(
-		context.Background(),
-		management.ContextAPIKeys,
-		map[string]management.APIKey{
-			"K8sAuth": {Key: "API_KEY_STRING"},
-		},
-	)
-r, err := client.Service.Operation(auth, args)
-```
-
 ### Recommended: dynamic auth (rotating tokens)
 
-The `ContextAPIKeys` examples above send a **static** value. For credentials
-that rotate — most notably the projected Kubernetes ServiceAccount token used
-with `K8sAuth` — use the hand-written `Auth` strategy instead. Its
-`AuthHeaders()` is resolved on **every request**, so rotated tokens are picked
-up automatically:
+The `ContextAPIKeys` example above sends a **static** value. For credentials
+that rotate — most notably the projected Kubernetes ServiceAccount token sent
+in the `X-Kubernetes-Authorization` header — use the hand-written `Auth`
+strategy instead. Its `AuthHeaders()` is resolved on **every request**, so
+rotated tokens are picked up automatically:
 
 ```go
 // Explicit Manage API token:
@@ -503,7 +482,10 @@ auth := management.NewKeboolaServiceAccountAuth("")
 // empty token -> KeboolaServiceAccountAuth at the default path:
 auth, err := management.NewAutoAuth(os.Getenv("KBC_MANAGE_TOKEN"))
 
-client := management.NewAPIClientWithAuth(management.NewConfiguration(), auth)
+client, err := management.NewAPIClientWithAuth(management.NewConfiguration(), auth)
+if err != nil {
+	log.Fatal(err) // auth must not be nil
+}
 resp, httpRes, err := client.TokenVerificationAPI.TokenVerification(ctx).Execute()
 ```
 

--- a/pkg/keboola/management/README.md
+++ b/pkg/keboola/management/README.md
@@ -454,6 +454,27 @@ auth := context.WithValue(
 r, err := client.Service.Operation(auth, args)
 ```
 
+### K8sAuth
+
+- **Type**: API key
+- **API key parameter name**: X-Kubernetes-Authorization
+- **Location**: HTTP header
+
+Note, each API key must be added to a map of `map[string]APIKey` where the key is: K8sAuth and passed in as the auth context for each request.
+
+Example
+
+```go
+auth := context.WithValue(
+		context.Background(),
+		management.ContextAPIKeys,
+		map[string]management.APIKey{
+			"K8sAuth": {Key: "API_KEY_STRING"},
+		},
+	)
+r, err := client.Service.Operation(auth, args)
+```
+
 
 ## Documentation for Utility Methods
 

--- a/pkg/keboola/management/README.md
+++ b/pkg/keboola/management/README.md
@@ -94,6 +94,10 @@ After regenerating, apply the following manual fixes:
 Hand-written files that are NOT generated and must be kept:
 - `auth_schemes.go` — exported security scheme and header name constants; update it if
   `securitySchemes` in `api/openapi.yaml` change
+- `auth.go` — `Auth` strategy interface with `ManageAPITokenAuth`,
+  `KeboolaServiceAccountAuth` and `NewAutoAuth`
+- `auth_transport.go` — `http.RoundTripper` applying an `Auth` per request and
+  the `NewAPIClientWithAuth` constructor
 
 ## Installation
 
@@ -478,6 +482,35 @@ auth := context.WithValue(
 	)
 r, err := client.Service.Operation(auth, args)
 ```
+
+### Recommended: dynamic auth (rotating tokens)
+
+The `ContextAPIKeys` examples above send a **static** value. For credentials
+that rotate — most notably the projected Kubernetes ServiceAccount token used
+with `K8sAuth` — use the hand-written `Auth` strategy instead. Its
+`AuthHeaders()` is resolved on **every request**, so rotated tokens are picked
+up automatically:
+
+```go
+// Explicit Manage API token:
+auth, err := management.NewManageAPITokenAuth("MANAGE_TOKEN")
+
+// Projected Kubernetes ServiceAccount token, re-read from disk per request
+// (empty path falls back to management.DefaultServiceAccountTokenPath):
+auth := management.NewKeboolaServiceAccountAuth("")
+
+// Auto-configuration: non-empty token -> ManageAPITokenAuth,
+// empty token -> KeboolaServiceAccountAuth at the default path:
+auth, err := management.NewAutoAuth(os.Getenv("KBC_MANAGE_TOKEN"))
+
+client := management.NewAPIClientWithAuth(management.NewConfiguration(), auth)
+resp, httpRes, err := client.TokenVerificationAPI.TokenVerification(ctx).Execute()
+```
+
+The `KeboolaServiceAccountAuth` sends `Bearer <token>` in the
+`X-Kubernetes-Authorization` header, matching the keboola-operator client.
+When an `Auth` is installed it takes precedence over headers set via
+`ContextAPIKeys` — use one mechanism or the other, not both.
 
 
 ## Documentation for Utility Methods

--- a/pkg/keboola/management/README.md
+++ b/pkg/keboola/management/README.md
@@ -91,6 +91,10 @@ After regenerating, apply the following manual fixes:
 - **ComponentAccess type**: Change from `*string` to `[]string`
 - **Redacted logging**: Ensure sensitive fields (passwords, secrets) use redacted logging
 
+Hand-written files that are NOT generated and must be kept:
+- `auth_schemes.go` — exported security scheme and header name constants; update it if
+  `securitySchemes` in `api/openapi.yaml` change
+
 ## Installation
 
 Install the following dependencies:

--- a/pkg/keboola/management/api/openapi.yaml
+++ b/pkg/keboola/management/api/openapi.yaml
@@ -96,6 +96,9 @@ paths:
       description: ""
       operationId: Token Verification
       parameters: []
+      security:
+      - ApiKeyAuth: []
+      - K8sAuth: []
       responses:
         "200":
           content:
@@ -9443,4 +9446,8 @@ components:
     ApiKeyAuth:
       in: header
       name: X-KBC-ManageApiToken
+      type: apiKey
+    K8sAuth:
+      in: header
+      name: X-Kubernetes-Authorization
       type: apiKey

--- a/pkg/keboola/management/api_token_verification.go
+++ b/pkg/keboola/management/api_token_verification.go
@@ -87,6 +87,20 @@ func (a *TokenVerificationAPIService) TokenVerificationExecute(r ApiTokenVerific
 	if r.ctx != nil {
 		// API Key Authentication
 		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
+			if apiKey, ok := auth["K8sAuth"]; ok {
+				var key string
+				if apiKey.Prefix != "" {
+					key = apiKey.Prefix + " " + apiKey.Key
+				} else {
+					key = apiKey.Key
+				}
+				localVarHeaderParams["X-Kubernetes-Authorization"] = key
+			}
+		}
+	}
+	if r.ctx != nil {
+		// API Key Authentication
+		if auth, ok := r.ctx.Value(ContextAPIKeys).(map[string]APIKey); ok {
 			if apiKey, ok := auth["ApiKeyAuth"]; ok {
 				var key string
 				if apiKey.Prefix != "" {

--- a/pkg/keboola/management/auth.go
+++ b/pkg/keboola/management/auth.go
@@ -1,0 +1,91 @@
+// Hand-written companion to the generated client — not produced by
+// openapi-generator, keep when regenerating.
+package management
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// DefaultServiceAccountTokenPath is the projected Kubernetes ServiceAccount
+// token mounted by the kbc-stacks chart.
+const DefaultServiceAccountTokenPath = "/var/run/secrets/connection.keboola.com/serviceaccount/token" //nolint:gosec // file path, not a credential
+
+// Auth resolves the authentication headers to attach to a Manage API request.
+// AuthHeaders is called per request so file-backed strategies (e.g. a projected
+// Kubernetes ServiceAccount token) pick up rotated tokens automatically.
+//
+// Use NewAPIClientWithAuth to build an APIClient that applies an Auth to
+// every outgoing request.
+type Auth interface {
+	AuthHeaders() (map[string]string, error)
+}
+
+// ManageAPITokenAuth authenticates with a static Keboola Manage API token
+// sent in the HeaderManageAPIToken header.
+type ManageAPITokenAuth struct {
+	token string
+}
+
+// NewManageAPITokenAuth creates a ManageAPITokenAuth. It errors if token is empty.
+func NewManageAPITokenAuth(token string) (*ManageAPITokenAuth, error) {
+	if token == "" {
+		return nil, fmt.Errorf("manage API token must not be empty")
+	}
+
+	return &ManageAPITokenAuth{token: token}, nil
+}
+
+func (a *ManageAPITokenAuth) AuthHeaders() (map[string]string, error) {
+	return map[string]string{HeaderManageAPIToken: a.token}, nil
+}
+
+// KeboolaServiceAccountAuth authenticates with a projected Kubernetes
+// ServiceAccount token sent as "Bearer <token>" in the
+// HeaderKubernetesAuthorization header. The file is read on every request so
+// kubelet-rotated tokens are picked up automatically.
+type KeboolaServiceAccountAuth struct {
+	tokenPath string
+}
+
+// NewKeboolaServiceAccountAuth creates a KeboolaServiceAccountAuth reading from tokenPath.
+// An empty tokenPath falls back to DefaultServiceAccountTokenPath.
+func NewKeboolaServiceAccountAuth(tokenPath string) *KeboolaServiceAccountAuth {
+	if tokenPath == "" {
+		tokenPath = DefaultServiceAccountTokenPath
+	}
+
+	return &KeboolaServiceAccountAuth{tokenPath: tokenPath}
+}
+
+func (a *KeboolaServiceAccountAuth) AuthHeaders() (map[string]string, error) {
+	data, err := os.ReadFile(a.tokenPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read service account token file %q: %w", a.tokenPath, err)
+	}
+
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return nil, fmt.Errorf("service account token file is empty: %q", a.tokenPath)
+	}
+
+	return map[string]string{HeaderKubernetesAuthorization: "Bearer " + token}, nil
+}
+
+// NewAutoAuth selects an Auth strategy automatically: a non-empty token yields
+// a ManageAPITokenAuth, an empty token falls back to a KeboolaServiceAccountAuth
+// reading the projected ServiceAccount token from DefaultServiceAccountTokenPath.
+func NewAutoAuth(token string) (Auth, error) {
+	if token != "" {
+		return NewManageAPITokenAuth(token)
+	}
+
+	return NewKeboolaServiceAccountAuth(""), nil
+}
+
+// Ensure both strategies implement Auth.
+var (
+	_ Auth = (*ManageAPITokenAuth)(nil)
+	_ Auth = (*KeboolaServiceAccountAuth)(nil)
+)

--- a/pkg/keboola/management/auth_schemes.go
+++ b/pkg/keboola/management/auth_schemes.go
@@ -1,0 +1,23 @@
+// Hand-written companion to the generated client — not produced by
+// openapi-generator, keep when regenerating.
+package management
+
+// Names of the security schemes defined in the Manage API OpenAPI spec
+// (api/openapi.yaml). Use them as keys in the ContextAPIKeys map:
+//
+//	ctx = context.WithValue(ctx, management.ContextAPIKeys,
+//	    map[string]management.APIKey{management.AuthSchemeAPIKey: {Key: token}})
+const (
+	// AuthSchemeAPIKey authenticates with a Manage API token
+	// sent in the HeaderManageAPIToken header.
+	AuthSchemeAPIKey = "ApiKeyAuth"
+	// AuthSchemeK8s authenticates with a Kubernetes service-account token
+	// sent in the HeaderKubernetesAuthorization header.
+	AuthSchemeK8s = "K8sAuth"
+)
+
+// HTTP header names used by the security schemes above.
+const (
+	HeaderManageAPIToken          = "X-KBC-ManageApiToken" //nolint:gosec // header name, not a credential
+	HeaderKubernetesAuthorization = "X-Kubernetes-Authorization"
+)

--- a/pkg/keboola/management/auth_transport.go
+++ b/pkg/keboola/management/auth_transport.go
@@ -1,0 +1,55 @@
+// Hand-written companion to the generated client — not produced by
+// openapi-generator, keep when regenerating.
+package management
+
+import "net/http"
+
+// authTransport injects Auth.AuthHeaders() into every outgoing request.
+//
+// Note: the generated callAPI dumps the request for debug logging before the
+// transport runs, so headers set here never appear in the debug dump and the
+// token is never logged.
+type authTransport struct {
+	base http.RoundTripper // nil falls back to http.DefaultTransport
+	auth Auth
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	headers, err := t.auth.AuthHeaders()
+	if err != nil {
+		return nil, err
+	}
+
+	// The RoundTripper contract forbids mutating the supplied request.
+	req = req.Clone(req.Context())
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	return base.RoundTrip(req)
+}
+
+// NewAPIClientWithAuth creates an APIClient that resolves authentication
+// headers via the given Auth on every request, so rotating credentials
+// (e.g. a projected Kubernetes ServiceAccount token) are picked up
+// automatically. When an Auth is installed it takes precedence over headers
+// set via ContextAPIKeys — use one mechanism or the other, not both.
+//
+// cfg.HTTPClient is shallow-copied before its transport is wrapped, so a
+// shared client (e.g. http.DefaultClient) is never mutated.
+func NewAPIClientWithAuth(cfg *Configuration, auth Auth) *APIClient {
+	httpClient := &http.Client{}
+	if cfg.HTTPClient != nil {
+		clientCopy := *cfg.HTTPClient
+		httpClient = &clientCopy
+	}
+	httpClient.Transport = &authTransport{base: httpClient.Transport, auth: auth}
+	cfg.HTTPClient = httpClient
+
+	return NewAPIClient(cfg)
+}

--- a/pkg/keboola/management/auth_transport.go
+++ b/pkg/keboola/management/auth_transport.go
@@ -2,7 +2,11 @@
 // openapi-generator, keep when regenerating.
 package management
 
-import "net/http"
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
 
 // authTransport injects Auth.AuthHeaders() into every outgoing request.
 //
@@ -23,6 +27,14 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// The RoundTripper contract forbids mutating the supplied request.
 	req = req.Clone(req.Context())
 	for k, v := range headers {
+		// The generated prepareRequest assigns header map keys directly,
+		// bypassing canonicalization — drop any case-insensitive duplicates
+		// (e.g. from ContextAPIKeys) so the Auth value is the only one sent.
+		for existing := range req.Header {
+			if strings.EqualFold(existing, k) {
+				delete(req.Header, existing)
+			}
+		}
 		req.Header.Set(k, v)
 	}
 
@@ -40,9 +52,16 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // automatically. When an Auth is installed it takes precedence over headers
 // set via ContextAPIKeys — use one mechanism or the other, not both.
 //
+// A nil auth is rejected with an error so a misconfigured client fails at
+// construction instead of panicking on the first request.
+//
 // cfg.HTTPClient is shallow-copied before its transport is wrapped, so a
 // shared client (e.g. http.DefaultClient) is never mutated.
-func NewAPIClientWithAuth(cfg *Configuration, auth Auth) *APIClient {
+func NewAPIClientWithAuth(cfg *Configuration, auth Auth) (*APIClient, error) {
+	if auth == nil {
+		return nil, errors.New("auth must not be nil")
+	}
+
 	httpClient := &http.Client{}
 	if cfg.HTTPClient != nil {
 		clientCopy := *cfg.HTTPClient
@@ -51,5 +70,5 @@ func NewAPIClientWithAuth(cfg *Configuration, auth Auth) *APIClient {
 	httpClient.Transport = &authTransport{base: httpClient.Transport, auth: auth}
 	cfg.HTTPClient = httpClient
 
-	return NewAPIClient(cfg)
+	return NewAPIClient(cfg), nil
 }

--- a/pkg/keboola/management/auth_transport.go
+++ b/pkg/keboola/management/auth_transport.go
@@ -26,15 +26,18 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// The RoundTripper contract forbids mutating the supplied request.
 	req = req.Clone(req.Context())
-	for k, v := range headers {
-		// The generated prepareRequest assigns header map keys directly,
-		// bypassing canonicalization — drop any case-insensitive duplicates
-		// (e.g. from ContextAPIKeys) so the Auth value is the only one sent.
-		for existing := range req.Header {
-			if strings.EqualFold(existing, k) {
-				delete(req.Header, existing)
-			}
+	// The Auth must be the only auth mechanism on the wire: strip every known
+	// auth header (e.g. set via ContextAPIKeys, possibly for a different
+	// scheme than the Auth uses) and any case-insensitive duplicate of a
+	// header we are about to set. The comparison must be case-insensitive
+	// because the generated prepareRequest assigns header map keys directly,
+	// bypassing canonicalization, so req.Header.Set alone would send both values.
+	for existing := range req.Header {
+		if isKnownAuthHeader(existing) || hasHeaderFold(headers, existing) {
+			delete(req.Header, existing)
 		}
+	}
+	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
 
@@ -44,6 +47,23 @@ func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	return base.RoundTrip(req)
+}
+
+// isKnownAuthHeader reports whether name is one of the authentication headers
+// defined by the API's security schemes (see auth_schemes.go).
+func isKnownAuthHeader(name string) bool {
+	return strings.EqualFold(name, HeaderManageAPIToken) ||
+		strings.EqualFold(name, HeaderKubernetesAuthorization)
+}
+
+// hasHeaderFold reports whether the header map contains name under any casing.
+func hasHeaderFold(headers map[string]string, name string) bool {
+	for k := range headers {
+		if strings.EqualFold(k, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // NewAPIClientWithAuth creates an APIClient that resolves authentication

--- a/pkg/keboola/management/client.go
+++ b/pkg/keboola/management/client.go
@@ -288,6 +288,7 @@ func redactSensitiveData(dump []byte) []byte {
 		"Authorization",
 		"X-StorageApi-Token",
 		"X-KBC-ManageApiToken",
+		"X-Kubernetes-Authorization",
 		"X-Api-Key",
 		"Cookie",
 		"Set-Cookie",

--- a/pkg/keboola/management/docs/TokenVerificationAPI.md
+++ b/pkg/keboola/management/docs/TokenVerificationAPI.md
@@ -25,7 +25,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	openapiclient "github.com/GIT_USER_ID/GIT_REPO_ID"
+	openapiclient "github.com/keboola/keboola-sdk-go/v2/pkg/keboola/management"
 )
 
 func main() {
@@ -57,7 +57,7 @@ Other parameters are passed through a pointer to a apiTokenVerificationRequest s
 
 ### Authorization
 
-[ApiKeyAuth](../README.md#ApiKeyAuth)
+[K8sAuth](../README.md#K8sAuth), [ApiKeyAuth](../README.md#ApiKeyAuth)
 
 ### HTTP request headers
 

--- a/pkg/keboola/management/docs/TokenVerificationAPI.md
+++ b/pkg/keboola/management/docs/TokenVerificationAPI.md
@@ -57,7 +57,7 @@ Other parameters are passed through a pointer to a apiTokenVerificationRequest s
 
 ### Authorization
 
-[K8sAuth](../README.md#K8sAuth), [ApiKeyAuth](../README.md#ApiKeyAuth)
+[K8sAuth](../README.md#recommended-dynamic-auth-rotating-tokens), [ApiKeyAuth](../README.md#ApiKeyAuth)
 
 ### HTTP request headers
 

--- a/pkg/keboola/management/test/auth_test.go
+++ b/pkg/keboola/management/test/auth_test.go
@@ -1,0 +1,156 @@
+package management
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	management "github.com/keboola/keboola-sdk-go/v2/pkg/keboola/management"
+)
+
+// newAuthTestServer returns a test server that records the headers of the
+// last request and responds with a valid token verification payload.
+func newAuthTestServer(headers *http.Header) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*headers = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"scopes": ["git-repo:manage"]}`))
+	}))
+}
+
+// newAuthTestClient returns an API client with the given Auth pointing at the test server.
+func newAuthTestClient(serverURL string, auth management.Auth) *management.APIClient {
+	cfg := management.NewConfiguration()
+	cfg.Servers = management.ServerConfigurations{{URL: serverURL}}
+	return management.NewAPIClientWithAuth(cfg, auth)
+}
+
+func Test_management_Auth_ManageAPITokenHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader http.Header
+	server := newAuthTestServer(&gotHeader)
+	defer server.Close()
+
+	auth, err := management.NewManageAPITokenAuth("manage-token")
+	require.NoError(t, err)
+
+	resp, httpRes, err := newAuthTestClient(server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
+	assert.Equal(t, "manage-token", gotHeader.Get("X-KBC-ManageApiToken"))
+	assert.Empty(t, gotHeader.Get("X-Kubernetes-Authorization"))
+}
+
+func Test_management_Auth_ManageAPIToken_Empty(t *testing.T) {
+	t.Parallel()
+
+	_, err := management.NewManageAPITokenAuth("")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "must not be empty")
+}
+
+func Test_management_Auth_ServiceAccountHeader(t *testing.T) {
+	t.Parallel()
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("k8s-token\n"), 0o600))
+
+	var gotHeader http.Header
+	server := newAuthTestServer(&gotHeader)
+	defer server.Close()
+
+	auth := management.NewKeboolaServiceAccountAuth(tokenPath)
+
+	resp, httpRes, err := newAuthTestClient(server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
+	assert.Equal(t, "Bearer k8s-token", gotHeader.Get("X-Kubernetes-Authorization"))
+	assert.Empty(t, gotHeader.Get("X-KBC-ManageApiToken"))
+}
+
+func Test_management_Auth_ServiceAccountTokenRotation(t *testing.T) {
+	t.Parallel()
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("token-a"), 0o600))
+
+	var gotHeader http.Header
+	server := newAuthTestServer(&gotHeader)
+	defer server.Close()
+
+	client := newAuthTestClient(server.URL, management.NewKeboolaServiceAccountAuth(tokenPath))
+
+	_, _, err := client.TokenVerificationAPI.TokenVerification(t.Context()).Execute()
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token-a", gotHeader.Get("X-Kubernetes-Authorization"))
+
+	// Simulate kubelet rotating the projected token; the next request must
+	// pick up the new value without rebuilding the client.
+	require.NoError(t, os.WriteFile(tokenPath, []byte("token-b"), 0o600))
+
+	_, _, err = client.TokenVerificationAPI.TokenVerification(t.Context()).Execute()
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer token-b", gotHeader.Get("X-Kubernetes-Authorization"))
+}
+
+func Test_management_Auth_ServiceAccountTokenFileMissing(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader http.Header
+	server := newAuthTestServer(&gotHeader)
+	defer server.Close()
+
+	auth := management.NewKeboolaServiceAccountAuth(filepath.Join(t.TempDir(), "missing"))
+
+	_, _, err := newAuthTestClient(server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to read service account token file")
+}
+
+func Test_management_Auth_ServiceAccountTokenFileEmpty(t *testing.T) {
+	t.Parallel()
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("  \n"), 0o600))
+
+	var gotHeader http.Header
+	server := newAuthTestServer(&gotHeader)
+	defer server.Close()
+
+	auth := management.NewKeboolaServiceAccountAuth(tokenPath)
+
+	_, _, err := newAuthTestClient(server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "service account token file is empty")
+}
+
+func Test_management_Auth_AutoAuthSelection(t *testing.T) {
+	t.Parallel()
+
+	auth, err := management.NewAutoAuth("manage-token")
+	require.NoError(t, err)
+	assert.IsType(t, &management.ManageAPITokenAuth{}, auth)
+
+	auth, err = management.NewAutoAuth("")
+	require.NoError(t, err)
+	assert.IsType(t, &management.KeboolaServiceAccountAuth{}, auth)
+}
+
+func Test_management_Auth_DoesNotMutateDefaultClient(t *testing.T) {
+	t.Parallel()
+
+	auth, err := management.NewManageAPITokenAuth("manage-token")
+	require.NoError(t, err)
+
+	before := http.DefaultClient.Transport
+	management.NewAPIClientWithAuth(management.NewConfiguration(), auth)
+	assert.Equal(t, before, http.DefaultClient.Transport)
+}

--- a/pkg/keboola/management/test/auth_test.go
+++ b/pkg/keboola/management/test/auth_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -24,10 +25,13 @@ func newAuthTestServer(headers *http.Header) *httptest.Server {
 }
 
 // newAuthTestClient returns an API client with the given Auth pointing at the test server.
-func newAuthTestClient(serverURL string, auth management.Auth) *management.APIClient {
+func newAuthTestClient(t *testing.T, serverURL string, auth management.Auth) *management.APIClient {
+	t.Helper()
 	cfg := management.NewConfiguration()
 	cfg.Servers = management.ServerConfigurations{{URL: serverURL}}
-	return management.NewAPIClientWithAuth(cfg, auth)
+	client, err := management.NewAPIClientWithAuth(cfg, auth)
+	require.NoError(t, err)
+	return client
 }
 
 func Test_management_Auth_ManageAPITokenHeader(t *testing.T) {
@@ -40,7 +44,7 @@ func Test_management_Auth_ManageAPITokenHeader(t *testing.T) {
 	auth, err := management.NewManageAPITokenAuth("manage-token")
 	require.NoError(t, err)
 
-	resp, httpRes, err := newAuthTestClient(server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
+	resp, httpRes, err := newAuthTestClient(t, server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -68,7 +72,7 @@ func Test_management_Auth_ServiceAccountHeader(t *testing.T) {
 
 	auth := management.NewKeboolaServiceAccountAuth(tokenPath)
 
-	resp, httpRes, err := newAuthTestClient(server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
+	resp, httpRes, err := newAuthTestClient(t, server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
@@ -86,7 +90,7 @@ func Test_management_Auth_ServiceAccountTokenRotation(t *testing.T) {
 	server := newAuthTestServer(&gotHeader)
 	defer server.Close()
 
-	client := newAuthTestClient(server.URL, management.NewKeboolaServiceAccountAuth(tokenPath))
+	client := newAuthTestClient(t, server.URL, management.NewKeboolaServiceAccountAuth(tokenPath))
 
 	_, _, err := client.TokenVerificationAPI.TokenVerification(t.Context()).Execute()
 	require.NoError(t, err)
@@ -110,7 +114,7 @@ func Test_management_Auth_ServiceAccountTokenFileMissing(t *testing.T) {
 
 	auth := management.NewKeboolaServiceAccountAuth(filepath.Join(t.TempDir(), "missing"))
 
-	_, _, err := newAuthTestClient(server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
+	_, _, err := newAuthTestClient(t, server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to read service account token file")
 }
@@ -127,7 +131,7 @@ func Test_management_Auth_ServiceAccountTokenFileEmpty(t *testing.T) {
 
 	auth := management.NewKeboolaServiceAccountAuth(tokenPath)
 
-	_, _, err := newAuthTestClient(server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
+	_, _, err := newAuthTestClient(t, server.URL, auth).TokenVerificationAPI.TokenVerification(t.Context()).Execute()
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "service account token file is empty")
 }
@@ -151,6 +155,37 @@ func Test_management_Auth_DoesNotMutateDefaultClient(t *testing.T) {
 	require.NoError(t, err)
 
 	before := http.DefaultClient.Transport
-	management.NewAPIClientWithAuth(management.NewConfiguration(), auth)
+	_, err = management.NewAPIClientWithAuth(management.NewConfiguration(), auth)
+	require.NoError(t, err)
 	assert.Equal(t, before, http.DefaultClient.Transport)
+}
+
+func Test_management_Auth_NilAuth(t *testing.T) {
+	t.Parallel()
+
+	client, err := management.NewAPIClientWithAuth(management.NewConfiguration(), nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "auth must not be nil")
+	assert.Nil(t, client)
+}
+
+func Test_management_Auth_TakesPrecedenceOverContextAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader http.Header
+	server := newAuthTestServer(&gotHeader)
+	defer server.Close()
+
+	auth, err := management.NewManageAPITokenAuth("auth-strategy-token")
+	require.NoError(t, err)
+
+	// Set the same header via ContextAPIKeys too — the Auth transport runs
+	// last and must win, as documented on NewAPIClientWithAuth.
+	ctx := context.WithValue(t.Context(), management.ContextAPIKeys, map[string]management.APIKey{
+		management.AuthSchemeAPIKey: {Key: "context-api-keys-token"},
+	})
+
+	_, _, err = newAuthTestClient(t, server.URL, auth).TokenVerificationAPI.TokenVerification(ctx).Execute()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"auth-strategy-token"}, gotHeader.Values(management.HeaderManageAPIToken))
 }

--- a/pkg/keboola/management/test/auth_test.go
+++ b/pkg/keboola/management/test/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,14 +15,25 @@ import (
 	management "github.com/keboola/keboola-sdk-go/v2/pkg/keboola/management"
 )
 
-// newAuthTestServer returns a test server that records the headers of the
-// last request and responds with a valid token verification payload.
-func newAuthTestServer(headers *http.Header) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		*headers = r.Header.Clone()
+// newAuthTestServer returns a test server that responds with a valid token
+// verification payload, plus an accessor for the headers of the last request.
+// The accessor is mutex-synchronized with the handler goroutine, so reading
+// it after a completed request is race-free.
+func newAuthTestServer() (*httptest.Server, func() http.Header) {
+	var mu sync.Mutex
+	var gotHeader http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotHeader = r.Header.Clone()
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"scopes": ["git-repo:manage"]}`))
 	}))
+	return server, func() http.Header {
+		mu.Lock()
+		defer mu.Unlock()
+		return gotHeader
+	}
 }
 
 // newAuthTestClient returns an API client with the given Auth pointing at the test server.
@@ -37,8 +49,7 @@ func newAuthTestClient(t *testing.T, serverURL string, auth management.Auth) *ma
 func Test_management_Auth_ManageAPITokenHeader(t *testing.T) {
 	t.Parallel()
 
-	var gotHeader http.Header
-	server := newAuthTestServer(&gotHeader)
+	server, gotHeader := newAuthTestServer()
 	defer server.Close()
 
 	auth, err := management.NewManageAPITokenAuth("manage-token")
@@ -48,8 +59,8 @@ func Test_management_Auth_ManageAPITokenHeader(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
-	assert.Equal(t, "manage-token", gotHeader.Get("X-KBC-ManageApiToken"))
-	assert.Empty(t, gotHeader.Get("X-Kubernetes-Authorization"))
+	assert.Equal(t, "manage-token", gotHeader().Get("X-KBC-ManageApiToken"))
+	assert.Empty(t, gotHeader().Get("X-Kubernetes-Authorization"))
 }
 
 func Test_management_Auth_ManageAPIToken_Empty(t *testing.T) {
@@ -66,8 +77,7 @@ func Test_management_Auth_ServiceAccountHeader(t *testing.T) {
 	tokenPath := filepath.Join(t.TempDir(), "token")
 	require.NoError(t, os.WriteFile(tokenPath, []byte("k8s-token\n"), 0o600))
 
-	var gotHeader http.Header
-	server := newAuthTestServer(&gotHeader)
+	server, gotHeader := newAuthTestServer()
 	defer server.Close()
 
 	auth := management.NewKeboolaServiceAccountAuth(tokenPath)
@@ -76,8 +86,8 @@ func Test_management_Auth_ServiceAccountHeader(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
-	assert.Equal(t, "Bearer k8s-token", gotHeader.Get("X-Kubernetes-Authorization"))
-	assert.Empty(t, gotHeader.Get("X-KBC-ManageApiToken"))
+	assert.Equal(t, "Bearer k8s-token", gotHeader().Get("X-Kubernetes-Authorization"))
+	assert.Empty(t, gotHeader().Get("X-KBC-ManageApiToken"))
 }
 
 func Test_management_Auth_ServiceAccountTokenRotation(t *testing.T) {
@@ -86,15 +96,14 @@ func Test_management_Auth_ServiceAccountTokenRotation(t *testing.T) {
 	tokenPath := filepath.Join(t.TempDir(), "token")
 	require.NoError(t, os.WriteFile(tokenPath, []byte("token-a"), 0o600))
 
-	var gotHeader http.Header
-	server := newAuthTestServer(&gotHeader)
+	server, gotHeader := newAuthTestServer()
 	defer server.Close()
 
 	client := newAuthTestClient(t, server.URL, management.NewKeboolaServiceAccountAuth(tokenPath))
 
 	_, _, err := client.TokenVerificationAPI.TokenVerification(t.Context()).Execute()
 	require.NoError(t, err)
-	assert.Equal(t, "Bearer token-a", gotHeader.Get("X-Kubernetes-Authorization"))
+	assert.Equal(t, "Bearer token-a", gotHeader().Get("X-Kubernetes-Authorization"))
 
 	// Simulate kubelet rotating the projected token; the next request must
 	// pick up the new value without rebuilding the client.
@@ -102,14 +111,13 @@ func Test_management_Auth_ServiceAccountTokenRotation(t *testing.T) {
 
 	_, _, err = client.TokenVerificationAPI.TokenVerification(t.Context()).Execute()
 	require.NoError(t, err)
-	assert.Equal(t, "Bearer token-b", gotHeader.Get("X-Kubernetes-Authorization"))
+	assert.Equal(t, "Bearer token-b", gotHeader().Get("X-Kubernetes-Authorization"))
 }
 
 func Test_management_Auth_ServiceAccountTokenFileMissing(t *testing.T) {
 	t.Parallel()
 
-	var gotHeader http.Header
-	server := newAuthTestServer(&gotHeader)
+	server, _ := newAuthTestServer()
 	defer server.Close()
 
 	auth := management.NewKeboolaServiceAccountAuth(filepath.Join(t.TempDir(), "missing"))
@@ -125,8 +133,7 @@ func Test_management_Auth_ServiceAccountTokenFileEmpty(t *testing.T) {
 	tokenPath := filepath.Join(t.TempDir(), "token")
 	require.NoError(t, os.WriteFile(tokenPath, []byte("  \n"), 0o600))
 
-	var gotHeader http.Header
-	server := newAuthTestServer(&gotHeader)
+	server, _ := newAuthTestServer()
 	defer server.Close()
 
 	auth := management.NewKeboolaServiceAccountAuth(tokenPath)
@@ -172,20 +179,22 @@ func Test_management_Auth_NilAuth(t *testing.T) {
 func Test_management_Auth_TakesPrecedenceOverContextAPIKeys(t *testing.T) {
 	t.Parallel()
 
-	var gotHeader http.Header
-	server := newAuthTestServer(&gotHeader)
+	server, gotHeader := newAuthTestServer()
 	defer server.Close()
 
 	auth, err := management.NewManageAPITokenAuth("auth-strategy-token")
 	require.NoError(t, err)
 
-	// Set the same header via ContextAPIKeys too — the Auth transport runs
-	// last and must win, as documented on NewAPIClientWithAuth.
+	// Set auth headers via ContextAPIKeys too — for the same scheme the Auth
+	// uses AND for the other scheme. The Auth transport runs last and must be
+	// the only auth mechanism on the wire, as documented on NewAPIClientWithAuth.
 	ctx := context.WithValue(t.Context(), management.ContextAPIKeys, map[string]management.APIKey{
 		management.AuthSchemeAPIKey: {Key: "context-api-keys-token"},
+		management.AuthSchemeK8s:    {Key: "context-api-keys-k8s-token"},
 	})
 
 	_, _, err = newAuthTestClient(t, server.URL, auth).TokenVerificationAPI.TokenVerification(ctx).Execute()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"auth-strategy-token"}, gotHeader.Values(management.HeaderManageAPIToken))
+	assert.Equal(t, []string{"auth-strategy-token"}, gotHeader().Values(management.HeaderManageAPIToken))
+	assert.Empty(t, gotHeader().Values(management.HeaderKubernetesAuthorization))
 }

--- a/pkg/keboola/management/test/token_verification_headers_test.go
+++ b/pkg/keboola/management/test/token_verification_headers_test.go
@@ -1,0 +1,68 @@
+package management
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	management "github.com/keboola/keboola-sdk-go/v2/pkg/keboola/management"
+)
+
+// newTestClient returns an API client pointing at the given test server.
+func newTestClient(serverURL string) *management.APIClient {
+	cfg := management.NewConfiguration()
+	cfg.Servers = management.ServerConfigurations{{URL: serverURL}}
+	return management.NewAPIClient(cfg)
+}
+
+func Test_management_TokenVerification_ApiKeyAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"scopes": ["git-repo:manage"]}`))
+	}))
+	defer server.Close()
+
+	ctx := context.WithValue(context.Background(), management.ContextAPIKeys, map[string]management.APIKey{
+		"ApiKeyAuth": {Key: "manage-token"},
+	})
+
+	resp, httpRes, err := newTestClient(server.URL).TokenVerificationAPI.TokenVerification(ctx).Execute()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
+	assert.Equal(t, "manage-token", gotHeader.Get("X-KBC-ManageApiToken"))
+	assert.Empty(t, gotHeader.Get("X-Kubernetes-Authorization"))
+	assert.Equal(t, []interface{}{"git-repo:manage"}, resp.GetScopes())
+}
+
+func Test_management_TokenVerification_K8sAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"scopes": ["git-repo:manage"]}`))
+	}))
+	defer server.Close()
+
+	ctx := context.WithValue(context.Background(), management.ContextAPIKeys, map[string]management.APIKey{
+		"K8sAuth": {Key: "k8s-token"},
+	})
+
+	resp, httpRes, err := newTestClient(server.URL).TokenVerificationAPI.TokenVerification(ctx).Execute()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
+	assert.Equal(t, "k8s-token", gotHeader.Get("X-Kubernetes-Authorization"))
+	assert.Empty(t, gotHeader.Get("X-KBC-ManageApiToken"))
+	assert.Equal(t, []interface{}{"git-repo:manage"}, resp.GetScopes())
+}

--- a/pkg/keboola/management/test/token_verification_headers_test.go
+++ b/pkg/keboola/management/test/token_verification_headers_test.go
@@ -3,7 +3,6 @@ package management
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,12 +21,7 @@ func newTestClient(serverURL string) *management.APIClient {
 func Test_management_TokenVerification_ApiKeyAuthHeader(t *testing.T) {
 	t.Parallel()
 
-	var gotHeader http.Header
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeader = r.Header.Clone()
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"scopes": ["git-repo:manage"]}`))
-	}))
+	server, gotHeader := newAuthTestServer()
 	defer server.Close()
 
 	ctx := context.WithValue(context.Background(), management.ContextAPIKeys, map[string]management.APIKey{
@@ -38,20 +32,15 @@ func Test_management_TokenVerification_ApiKeyAuthHeader(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
-	assert.Equal(t, "manage-token", gotHeader.Get(management.HeaderManageAPIToken))
-	assert.Empty(t, gotHeader.Get(management.HeaderKubernetesAuthorization))
+	assert.Equal(t, "manage-token", gotHeader().Get(management.HeaderManageAPIToken))
+	assert.Empty(t, gotHeader().Get(management.HeaderKubernetesAuthorization))
 	assert.Equal(t, []interface{}{"git-repo:manage"}, resp.GetScopes())
 }
 
 func Test_management_TokenVerification_K8sAuthHeader(t *testing.T) {
 	t.Parallel()
 
-	var gotHeader http.Header
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeader = r.Header.Clone()
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"scopes": ["git-repo:manage"]}`))
-	}))
+	server, gotHeader := newAuthTestServer()
 	defer server.Close()
 
 	ctx := context.WithValue(context.Background(), management.ContextAPIKeys, map[string]management.APIKey{
@@ -62,7 +51,7 @@ func Test_management_TokenVerification_K8sAuthHeader(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
-	assert.Equal(t, "k8s-token", gotHeader.Get(management.HeaderKubernetesAuthorization))
-	assert.Empty(t, gotHeader.Get(management.HeaderManageAPIToken))
+	assert.Equal(t, "k8s-token", gotHeader().Get(management.HeaderKubernetesAuthorization))
+	assert.Empty(t, gotHeader().Get(management.HeaderManageAPIToken))
 	assert.Equal(t, []interface{}{"git-repo:manage"}, resp.GetScopes())
 }

--- a/pkg/keboola/management/test/token_verification_headers_test.go
+++ b/pkg/keboola/management/test/token_verification_headers_test.go
@@ -31,15 +31,15 @@ func Test_management_TokenVerification_ApiKeyAuthHeader(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.WithValue(context.Background(), management.ContextAPIKeys, map[string]management.APIKey{
-		"ApiKeyAuth": {Key: "manage-token"},
+		management.AuthSchemeAPIKey: {Key: "manage-token"},
 	})
 
 	resp, httpRes, err := newTestClient(server.URL).TokenVerificationAPI.TokenVerification(ctx).Execute()
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
-	assert.Equal(t, "manage-token", gotHeader.Get("X-KBC-ManageApiToken"))
-	assert.Empty(t, gotHeader.Get("X-Kubernetes-Authorization"))
+	assert.Equal(t, "manage-token", gotHeader.Get(management.HeaderManageAPIToken))
+	assert.Empty(t, gotHeader.Get(management.HeaderKubernetesAuthorization))
 	assert.Equal(t, []interface{}{"git-repo:manage"}, resp.GetScopes())
 }
 
@@ -55,14 +55,14 @@ func Test_management_TokenVerification_K8sAuthHeader(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.WithValue(context.Background(), management.ContextAPIKeys, map[string]management.APIKey{
-		"K8sAuth": {Key: "k8s-token"},
+		management.AuthSchemeK8s: {Key: "k8s-token"},
 	})
 
 	resp, httpRes, err := newTestClient(server.URL).TokenVerificationAPI.TokenVerification(ctx).Execute()
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, httpRes.StatusCode)
-	assert.Equal(t, "k8s-token", gotHeader.Get("X-Kubernetes-Authorization"))
-	assert.Empty(t, gotHeader.Get("X-KBC-ManageApiToken"))
+	assert.Equal(t, "k8s-token", gotHeader.Get(management.HeaderKubernetesAuthorization))
+	assert.Empty(t, gotHeader.Get(management.HeaderManageAPIToken))
 	assert.Equal(t, []interface{}{"git-repo:manage"}, resp.GetScopes())
 }


### PR DESCRIPTION
**Changes:**
- Add `K8sAuth` apiKey security scheme (`X-Kubernetes-Authorization` header) to the Manage API OpenAPI spec
- Allow `K8sAuth` alongside `ApiKeyAuth` on `GET /manage/tokens/verify`
- Regenerate `api_token_verification.go` with openapi-generator 7.19.0 (only this operation changed; manual fixes in `client.go`/models preserved)
- Add `X-Kubernetes-Authorization` to the redacted-headers list in debug logging
- Export auth scheme and header name constants (`AuthSchemeAPIKey`, `AuthSchemeK8s`, `HeaderManageAPIToken`, …)
- Add per-request `Auth` strategy (`ManageAPITokenAuth`, `KeboolaServiceAccountAuth`, `NewAutoAuth`) with SA token auto-rotation, applied via `NewAPIClientWithAuth` — matches the keboola-operator and PHP client approach
- `NewAPIClientWithAuth` rejects a nil `Auth` with an error (fail-fast at construction) and the auth transport enforces `Auth` precedence over `ContextAPIKeys` headers
- Add unit tests for both auth schemes, token rotation, nil-auth, and the `Auth`-over-`ContextAPIKeys` precedence contract

-----------

Linear: https://linear.app/keboola/issue/PSGO-256/add-support-for-manage-sdk-in-go-monorepo

Context: `git-service` in go-monorepo currently hand-rolls the HTTP request for Kubernetes token verification because the generated client only knew `ApiKeyAuth` (keboola/go-monorepo#524). With this change the SDK covers both paths via the `Auth` strategy:

```go
// Auto-configuration: non-empty token -> ManageAPITokenAuth,
// empty token -> KeboolaServiceAccountAuth (projected SA token,
// re-read from disk on every request so rotation is picked up):
auth, err := management.NewAutoAuth(os.Getenv("KBC_MANAGE_TOKEN"))
client, err := management.NewAPIClientWithAuth(management.NewConfiguration(), auth)
resp, httpResp, err := client.TokenVerificationAPI.TokenVerification(ctx).Execute()
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)