### PR TITLE
test(keboola): sort table columns before comparison (PK-first ordering)

### DIFF
--- a/pkg/keboola/storage_table_test.go
+++ b/pkg/keboola/storage_table_test.go
@@ -333,7 +333,9 @@ func TestWithoutDefinition(t *testing.T) {
 	// dynamic fields above before the full comparison.
 	require.NotNil(t, resTab.Definition)
 	assert.Equal(t, []string{"name"}, resTab.Definition.PrimaryKeyNames)
-	assert.Equal(t, []string{"name", "age", "time"}, resTab.Definition.Columns.Names())
+	// Order-insensitive: removeDynamicValueFromTable sorts columns by name, and
+	// the API may return them primary-key-first; only the set of names matters here.
+	assert.ElementsMatch(t, []string{"name", "age", "time"}, resTab.Definition.Columns.Names())
 	for _, c := range resTab.Definition.Columns {
 		assert.Nil(t, c.Definition)
 	}

--- a/pkg/keboola/storage_table_test.go
+++ b/pkg/keboola/storage_table_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sort"
 	"testing"
 	"time"
 
@@ -230,6 +231,7 @@ func TestCreateTableDefinition(t *testing.T) {
 
 		maxUseCaseTable, err := api.GetTableRequest(maxUseCaseTableKey).Send(ctx)
 		require.NoError(t, err)
+		sortTableColumnsByName(maxUseCaseTable.Definition.Columns)
 		assert.Equal(t, Columns{
 			{
 				Name: "comments",
@@ -760,4 +762,17 @@ func removeDynamicValueFromTable(table *Table) {
 	table.LastChangeDate = nil
 	table.Bucket.Created = iso8601.Time{}
 	table.Bucket.LastChangeDate = nil
+	// Normalize column order: the Storage API returns primary-key columns first,
+	// while these tests declare expected columns alphabetically by name.
+	if table.Definition != nil {
+		sortTableColumnsByName(table.Definition.Columns)
+	}
+}
+
+// sortTableColumnsByName sorts a table definition's columns by name, making
+// column-order-sensitive assertions order-insensitive.
+func sortTableColumnsByName(cols Columns) {
+	sort.Slice(cols, func(i, j int) bool {
+		return cols[i].Name < cols[j].Name
+	})
 }


### PR DESCRIPTION
## What & why

`TestCreateTableDefinition` and `TestCreateTableDefinitionWithBigQuery` fail on a pure **column-ordering** difference: the Storage API now returns **primary-key columns first**, while the tests assert columns in alphabetical order. The struct comparison (`assert.Equal` on the whole `Table`) is order-sensitive, so e.g. PK `name` returned first didn't match the expected `age, name, time`.

## Fix

Normalize the actual column order by name before comparing:
- `removeDynamicValueFromTable` now sorts `Definition.Columns` by name (covers the two `assert.Equal(t, &Table{…})` checks).
- The one `maxUseCase` assertion that compares `Definition.Columns` directly (and doesn't use that helper) gets an explicit `sortTableColumnsByName` call.

The other `removeDynamicValueFromTable` callers are unaffected — their expected columns are already alphabetical (`id, time`), so the sort is a no-op there.

## Notes

- `go vet ./pkg/keboola/` compiles clean; gofmt clean. These are integration tests requiring live projects, so they were not executed locally.
- This does **not** address the separate `TestResetEditorSessionCredentials` failure (editor endpoint returns HTTP 400 with no captured body — looks environmental/backend-state, not a code/path bug; the request URL is well-formed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)