### PR TITLE
chore: drop provisioningStrategy from sandboxes app model

### DIFF
--- a/pkg/keboola/datascienceapp.go
+++ b/pkg/keboola/datascienceapp.go
@@ -32,31 +32,27 @@ type DataScienceAppState string
 // DataScienceAppDesiredState is the desired lifecycle state of a data science app.
 type DataScienceAppDesiredState string
 
-// DataScienceAppProvisioningStrategy is the provisioning strategy of a data science app.
-type DataScienceAppProvisioningStrategy string
-
 // DataScienceApp represents a data science app returned by the data-science service /apps endpoint.
 // It replaces the deprecated SandboxWorkspace for listing and status checks.
 // Field mapping from old SandboxWorkspace: ID→ID, Type→Type (narrowed), Active(bool)→State+DesiredState,
 // Size→Size, URL→URL, BranchID→BranchID, ConfigurationID→ConfigID.
 // Connection details (User/Password/Host/Credentials) are not exposed here.
 type DataScienceApp struct {
-	ID                      DataScienceAppID                   `json:"id"`
-	Type                    DataScienceAppType                 `json:"type"`
-	ProjectID               string                             `json:"projectId"`
-	ComponentID             ComponentID                        `json:"componentId"`
-	BranchID                string                             `json:"branchId"`
-	ConfigID                string                             `json:"configId"`
-	ConfigVersion           string                             `json:"configVersion"`
-	State                   DataScienceAppState                `json:"state"`
-	DesiredState            DataScienceAppDesiredState         `json:"desiredState"`
-	LastRequestTimestamp    iso8601.Time                       `json:"lastRequestTimestamp"`
-	LastStartTimestamp      iso8601.Time                       `json:"lastStartTimestamp"`
-	URL                     string                             `json:"url"`
-	AutoSuspendAfterSeconds int                                `json:"autoSuspendAfterSeconds"`
-	AutoRestartEnabled      bool                               `json:"autoRestartEnabled"`
-	Size                    string                             `json:"size"`
-	ProvisioningStrategy    DataScienceAppProvisioningStrategy `json:"provisioningStrategy"`
+	ID                      DataScienceAppID           `json:"id"`
+	Type                    DataScienceAppType         `json:"type"`
+	ProjectID               string                     `json:"projectId"`
+	ComponentID             ComponentID                `json:"componentId"`
+	BranchID                string                     `json:"branchId"`
+	ConfigID                string                     `json:"configId"`
+	ConfigVersion           string                     `json:"configVersion"`
+	State                   DataScienceAppState        `json:"state"`
+	DesiredState            DataScienceAppDesiredState `json:"desiredState"`
+	LastRequestTimestamp    iso8601.Time               `json:"lastRequestTimestamp"`
+	LastStartTimestamp      iso8601.Time               `json:"lastStartTimestamp"`
+	URL                     string                     `json:"url"`
+	AutoSuspendAfterSeconds int                        `json:"autoSuspendAfterSeconds"`
+	AutoRestartEnabled      bool                       `json:"autoRestartEnabled"`
+	Size                    string                     `json:"size"`
 }
 
 type listDataScienceAppsConfig struct {


### PR DESCRIPTION
## Release Notes
https://github.com/keboola/sandboxes-service/pull/631

The `data-science` service is dropping the `provisioningStrategy` field from its `GET /apps` (and `GET /apps/{appId}`) response, so this SDK no longer needs to model it. This removes the `ProvisioningStrategy` field (and its `DataScienceAppProvisioningStrategy` type) from the `DataScienceApp` struct in `pkg/keboola/datascienceapp.go`. The field was an unused, output-only attribute; no other code referenced it.

## Plans for customer communication
None.

## Impact analysis
No end-user impact. The removed field was output-only and unused; JSON decoding silently ignores the now-absent `provisioningStrategy` key. Any consumer that read `DataScienceApp.ProvisioningStrategy` would need to drop that reference, but there are no such consumers in this repo.

## Change type
Maintenance

## Justification
Keep the SDK model in sync with the data-science `/apps` response, which no longer returns `provisioningStrategy` (see keboola/sandboxes-service#631).

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
