### PR TITLE
test(keboola): use keypair login type in TestStorageWorkspaceUnload

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,7 +32,6 @@ jobs:
           TEST_KBC_PROJECTS_LOCK_HOST: ${{ vars.TEST_KBC_PROJECTS_LOCK_HOST }}
           TEST_KBC_PROJECTS_LOCK_PASSWORD: ${{ secrets.TEST_KBC_PROJECTS_LOCK_PASSWORD }}
           TEST_KBC_PROJECTS_FILE: '${{ github.workspace }}/${{ vars.TEST_KBC_PROJECTS_FILE }}'
-          TEST_SNOWFLAKE_PUBLIC_KEY: ${{ secrets.TEST_SNOWFLAKE_PUBLIC_KEY }}
         run: |
           task lint
           task tests

--- a/build/ci/projects.json
+++ b/build/ci/projects.json
@@ -4,28 +4,32 @@
         "project": 10378,
         "token": "$TEST_KBC_PROJECT_AWS_US_10378_TOKEN",
         "stagingStorage": "s3",
-        "backend": "snowflake"
+        "backend": "snowflake",
+        "legacyTransformation": true
     },
     {
         "host": "connection.keboola.com",
         "project": 10382,
         "token": "$TEST_KBC_PROJECT_AWS_US_10382_TOKEN",
         "stagingStorage": "s3",
-        "backend": "snowflake"
+        "backend": "snowflake",
+        "legacyTransformation": true
     },
     {
         "host": "connection.north-europe.azure.keboola.com",
         "project": 24246,
         "token": "$TEST_KBC_PROJECT_AZURE_NE_24246_TOKEN",
         "stagingStorage": "abs",
-        "backend": "snowflake"
+        "backend": "snowflake",
+        "legacyTransformation": true
     },
     {
         "host": "connection.north-europe.azure.keboola.com",
         "project": 24336,
         "token": "$TEST_KBC_PROJECT_AZURE_NE_24336_TOKEN",
         "stagingStorage": "abs",
-        "backend": "snowflake"
+        "backend": "snowflake",
+        "legacyTransformation": true
     },
     {
         "host": "connection.us-east4.gcp.keboola.com",
@@ -40,5 +44,19 @@
         "token": "$TEST_KBC_PROJECT_GCP_US_826_TOKEN",
         "stagingStorage": "gcs",
         "backend": "bigquery"
+    },
+    {
+        "host": "connection.us-east4.gcp.keboola.com",
+        "project": 6084,
+        "token": "$TEST_KBC_PROJECT_GCP_US_6084_TOKEN",
+        "stagingStorage": "gcs",
+        "backend": "snowflake"
+    },
+    {
+        "host": "connection.us-east4.gcp.keboola.com",
+        "project": 6083,
+        "token": "$TEST_KBC_PROJECT_GCP_US_6083_TOKEN",
+        "stagingStorage": "gcs",
+        "backend": "snowflake"
     }
 ]

--- a/build/ci/projects.json
+++ b/build/ci/projects.json
@@ -4,32 +4,28 @@
         "project": 10378,
         "token": "$TEST_KBC_PROJECT_AWS_US_10378_TOKEN",
         "stagingStorage": "s3",
-        "backend": "snowflake",
-        "legacyTransformation": true
+        "backend": "snowflake"
     },
     {
         "host": "connection.keboola.com",
         "project": 10382,
         "token": "$TEST_KBC_PROJECT_AWS_US_10382_TOKEN",
         "stagingStorage": "s3",
-        "backend": "snowflake",
-        "legacyTransformation": true
+        "backend": "snowflake"
     },
     {
         "host": "connection.north-europe.azure.keboola.com",
         "project": 24246,
         "token": "$TEST_KBC_PROJECT_AZURE_NE_24246_TOKEN",
         "stagingStorage": "abs",
-        "backend": "snowflake",
-        "legacyTransformation": true
+        "backend": "snowflake"
     },
     {
         "host": "connection.north-europe.azure.keboola.com",
         "project": 24336,
         "token": "$TEST_KBC_PROJECT_AZURE_NE_24336_TOKEN",
         "stagingStorage": "abs",
-        "backend": "snowflake",
-        "legacyTransformation": true
+        "backend": "snowflake"
     },
     {
         "host": "connection.us-east4.gcp.keboola.com",

--- a/pkg/keboola/storage_config_workspace_test.go
+++ b/pkg/keboola/storage_config_workspace_test.go
@@ -2,7 +2,6 @@ package keboola_test
 
 import (
 	"context"
-	"os"
 	"slices"
 	"testing"
 	"time"
@@ -67,7 +66,7 @@ func TestConfigWorkspacesCreateAndListSnowflake(t *testing.T) {
 			NetworkPolicy:         &networkPolicy,
 			ReadOnlyStorageAccess: true,
 			LoginType:             keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-			PublicKey:             new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
+			PublicKey:             new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
 		},
 		UseCase: keboola.StorageWorkspaceUseCaseNormal,
 	}

--- a/pkg/keboola/storage_config_workspace_test.go
+++ b/pkg/keboola/storage_config_workspace_test.go
@@ -65,7 +65,7 @@ func TestConfigWorkspacesCreateAndListSnowflake(t *testing.T) {
 			NetworkPolicy:         &networkPolicy,
 			ReadOnlyStorageAccess: true,
 			LoginType:             keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-			PublicKey:             new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
+			PublicKey:             new(keboola.GenerateRSAPublicKeyPEM(t)),
 		},
 		UseCase: keboola.StorageWorkspaceUseCaseNormal,
 	}

--- a/pkg/keboola/storage_config_workspace_test.go
+++ b/pkg/keboola/storage_config_workspace_test.go
@@ -62,7 +62,6 @@ func TestConfigWorkspacesCreateAndListSnowflake(t *testing.T) {
 	workspace := &keboola.StorageConfigWorkspacePayload{
 		StorageWorkspacePayload: keboola.StorageWorkspacePayload{
 			Backend:               keboola.StorageWorkspaceBackendSnowflake,
-			BackendSize:           new(keboola.StorageWorkspaceBackendSizeMedium),
 			NetworkPolicy:         &networkPolicy,
 			ReadOnlyStorageAccess: true,
 			LoginType:             keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
@@ -83,7 +82,6 @@ func TestConfigWorkspacesCreateAndListSnowflake(t *testing.T) {
 	})
 
 	assert.Equal(t, keboola.StorageWorkspaceBackendSnowflake, createdWorkspace.StorageWorkspaceDetails.Backend)
-	assert.Equal(t, keboola.StorageWorkspaceBackendSizeMedium, *createdWorkspace.BackendSize)
 	assert.Equal(t, string(keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair), *createdWorkspace.StorageWorkspaceDetails.LoginType)
 
 	// List configuration workspaces - should contain the created workspace

--- a/pkg/keboola/storage_workspace_table_export_test.go
+++ b/pkg/keboola/storage_workspace_table_export_test.go
@@ -33,7 +33,7 @@ func TestWorkspaceTableExport(t *testing.T) {
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
+		PublicKey:     new(keboola.GenerateRSAPublicKeyPEM(t)),
 	}
 
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)

--- a/pkg/keboola/storage_workspace_table_export_test.go
+++ b/pkg/keboola/storage_workspace_table_export_test.go
@@ -2,7 +2,6 @@ package keboola_test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -35,7 +34,7 @@ func TestWorkspaceTableExport(t *testing.T) {
 		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
+		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
 	}
 
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)

--- a/pkg/keboola/storage_workspace_table_export_test.go
+++ b/pkg/keboola/storage_workspace_table_export_test.go
@@ -31,7 +31,6 @@ func TestWorkspaceTableExport(t *testing.T) {
 	networkPolicy := "user"
 	workspace := &keboola.StorageWorkspacePayload{
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
-		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
 		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),

--- a/pkg/keboola/storage_workspaces_test.go
+++ b/pkg/keboola/storage_workspaces_test.go
@@ -122,10 +122,11 @@ func TestStorageWorkspacesCreateWrongBigQuery(t *testing.T) {
 	require.NoError(t, err)
 	initialLen := len(*workspaces)
 
-	// Create workspace - should fail
+	// Create workspace - should fail, backendSize is not supported (dynamic backends)
 	workspace := &keboola.StorageWorkspacePayload{
-		Backend:   keboola.StorageWorkspaceBackendBigQuery,
-		LoginType: keboola.StorageWorkspaceLoginTypeDefault,
+		Backend:     keboola.StorageWorkspaceBackendBigQuery,
+		BackendSize: new(keboola.StorageWorkspaceBackendSizeMedium),
+		LoginType:   keboola.StorageWorkspaceLoginTypeDefault,
 	}
 
 	_, err = api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)

--- a/pkg/keboola/storage_workspaces_test.go
+++ b/pkg/keboola/storage_workspaces_test.go
@@ -147,7 +147,10 @@ func TestStorageWorkspacesCreateWrongBigQuery(t *testing.T) {
 func TestStorageWorkspaceUnload(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithSnowflakeBackend(), testproject.WithLegacyTransformation())
+	// Workspaces with the default (legacy service) login type can no longer be created
+	// on the projects flagged legacyTransformation. testproject has no negative filter,
+	// so select the non-legacy Snowflake projects via their GCS staging storage.
+	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithSnowflakeBackend(), testproject.WithStagingStorage(testproject.StagingStorageGCS))
 
 	ctx, cancelFn := context.WithTimeout(ctx, time.Minute*10)
 	defer cancelFn()

--- a/pkg/keboola/storage_workspaces_test.go
+++ b/pkg/keboola/storage_workspaces_test.go
@@ -147,10 +147,7 @@ func TestStorageWorkspacesCreateWrongBigQuery(t *testing.T) {
 func TestStorageWorkspaceUnload(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	// Workspaces with the default (legacy service) login type can no longer be created
-	// on the projects flagged legacyTransformation. testproject has no negative filter,
-	// so select the non-legacy Snowflake projects via their GCS staging storage.
-	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithSnowflakeBackend(), testproject.WithStagingStorage(testproject.StagingStorageGCS))
+	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithSnowflakeBackend())
 
 	ctx, cancelFn := context.WithTimeout(ctx, time.Minute*10)
 	defer cancelFn()
@@ -161,7 +158,8 @@ func TestStorageWorkspaceUnload(t *testing.T) {
 	// Create workspace
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
 		Backend:   keboola.StorageWorkspaceBackendSnowflake,
-		LoginType: keboola.StorageWorkspaceLoginTypeDefault,
+		LoginType: keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
+		PublicKey: new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
 	}).Send(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -187,7 +185,8 @@ func TestStorageWorkspaceUnload(t *testing.T) {
 	// Without a configuration the API skips the drop and returns an empty job list.
 	workspace2, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
 		Backend:   keboola.StorageWorkspaceBackendSnowflake,
-		LoginType: keboola.StorageWorkspaceLoginTypeDefault,
+		LoginType: keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
+		PublicKey: new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
 	}).Send(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/pkg/keboola/storage_workspaces_test.go
+++ b/pkg/keboola/storage_workspaces_test.go
@@ -31,7 +31,7 @@ func TestStorageWorkspacesCreateAndDeleteSnowflake(t *testing.T) {
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
+		PublicKey:     new(keboola.GenerateRSAPublicKeyPEM(t)),
 	}
 
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)
@@ -155,7 +155,7 @@ func TestStorageWorkspaceUnload(t *testing.T) {
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
 		Backend:   keboola.StorageWorkspaceBackendSnowflake,
 		LoginType: keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey: new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
+		PublicKey: new(keboola.GenerateRSAPublicKeyPEM(t)),
 	}).Send(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -182,7 +182,7 @@ func TestStorageWorkspaceUnload(t *testing.T) {
 	workspace2, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
 		Backend:   keboola.StorageWorkspaceBackendSnowflake,
 		LoginType: keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey: new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
+		PublicKey: new(keboola.GenerateRSAPublicKeyPEM(t)),
 	}).Send(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/pkg/keboola/storage_workspaces_test.go
+++ b/pkg/keboola/storage_workspaces_test.go
@@ -29,7 +29,6 @@ func TestStorageWorkspacesCreateAndDeleteSnowflake(t *testing.T) {
 	networkPolicy := "user"
 	workspace := &keboola.StorageWorkspacePayload{
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
-		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
 		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
@@ -47,7 +46,6 @@ func TestStorageWorkspacesCreateAndDeleteSnowflake(t *testing.T) {
 	})
 
 	assert.Equal(t, keboola.StorageWorkspaceBackendSnowflake, createdWorkspace.StorageWorkspaceDetails.Backend)
-	assert.Equal(t, keboola.StorageWorkspaceBackendSizeMedium, *createdWorkspace.BackendSize)
 	assert.Equal(t, string(keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair), *createdWorkspace.StorageWorkspaceDetails.LoginType)
 
 	// Get workspace details
@@ -56,7 +54,6 @@ func TestStorageWorkspacesCreateAndDeleteSnowflake(t *testing.T) {
 	require.NotNil(t, retrievedWorkspace)
 	assert.Equal(t, createdWorkspace.ID, retrievedWorkspace.ID)
 	assert.Equal(t, createdWorkspace.StorageWorkspaceDetails.Backend, retrievedWorkspace.StorageWorkspaceDetails.Backend)
-	assert.Equal(t, createdWorkspace.BackendSize, retrievedWorkspace.BackendSize)
 	assert.Equal(t, createdWorkspace.StorageWorkspaceDetails.LoginType, retrievedWorkspace.StorageWorkspaceDetails.LoginType)
 
 	// Create credentials
@@ -127,9 +124,8 @@ func TestStorageWorkspacesCreateWrongBigQuery(t *testing.T) {
 
 	// Create workspace - should fail
 	workspace := &keboola.StorageWorkspacePayload{
-		Backend:     keboola.StorageWorkspaceBackendBigQuery,
-		BackendSize: new(keboola.StorageWorkspaceBackendSizeMedium),
-		LoginType:   keboola.StorageWorkspaceLoginTypeDefault,
+		Backend:   keboola.StorageWorkspaceBackendBigQuery,
+		LoginType: keboola.StorageWorkspaceLoginTypeDefault,
 	}
 
 	_, err = api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)
@@ -249,7 +245,6 @@ func TestStorageWorkspacesCreateAndDeleteBigQuery(t *testing.T) {
 	assert.NotNil(t, retrievedWorkspace)
 	assert.Equal(t, createdWorkspace.ID, retrievedWorkspace.ID)
 	assert.Equal(t, createdWorkspace.StorageWorkspaceDetails.Backend, retrievedWorkspace.StorageWorkspaceDetails.Backend)
-	assert.Equal(t, createdWorkspace.BackendSize, retrievedWorkspace.BackendSize)
 	assert.Equal(t, createdWorkspace.StorageWorkspaceDetails.LoginType, retrievedWorkspace.StorageWorkspaceDetails.LoginType)
 
 	// Create credentials

--- a/pkg/keboola/storage_workspaces_test.go
+++ b/pkg/keboola/storage_workspaces_test.go
@@ -147,7 +147,7 @@ func TestStorageWorkspacesCreateWrongBigQuery(t *testing.T) {
 func TestStorageWorkspaceUnload(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithSnowflakeBackend())
+	_, api := keboola.APIClientForAnEmptyProject(t, ctx, testproject.WithSnowflakeBackend(), testproject.WithLegacyTransformation())
 
 	ctx, cancelFn := context.WithTimeout(ctx, time.Minute*10)
 	defer cancelFn()

--- a/pkg/keboola/storage_workspaces_test.go
+++ b/pkg/keboola/storage_workspaces_test.go
@@ -2,7 +2,6 @@ package keboola_test
 
 import (
 	"context"
-	"os"
 	"slices"
 	"testing"
 	"time"
@@ -33,7 +32,7 @@ func TestStorageWorkspacesCreateAndDeleteSnowflake(t *testing.T) {
 		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
+		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
 	}
 
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)
@@ -159,7 +158,7 @@ func TestStorageWorkspaceUnload(t *testing.T) {
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
 		Backend:   keboola.StorageWorkspaceBackendSnowflake,
 		LoginType: keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey: new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
+		PublicKey: new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
 	}).Send(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -186,7 +185,7 @@ func TestStorageWorkspaceUnload(t *testing.T) {
 	workspace2, err := api.StorageWorkspaceCreateRequest(defBranch.ID, &keboola.StorageWorkspacePayload{
 		Backend:   keboola.StorageWorkspaceBackendSnowflake,
 		LoginType: keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey: new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
+		PublicKey: new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
 	}).Send(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/pkg/keboola/test.go
+++ b/pkg/keboola/test.go
@@ -15,42 +15,21 @@ import (
 	"github.com/keboola/keboola-sdk-go/v2/pkg/client"
 )
 
-// RSAKeyPair holds a generated RSA key pair in both PEM-encoded and raw form.
-type RSAKeyPair struct {
-	PrivateKeyPEM []byte
-	PublicKeyPEM  []byte
-	PrivateKey    *rsa.PrivateKey
-	PublicKey     *rsa.PublicKey
-}
-
-// GenerateRSAKeyPairPKCS1 creates a new RSA key pair and returns the private key in PKCS1 format.
-// This is useful for compatibility with systems that expect PKCS1 format (like some Snowflake configurations).
-// Returns both PEM-encoded keys and the raw key objects.
-func GenerateRSAKeyPairPKCS1(t *testing.T) *RSAKeyPair {
+// GenerateRSAPublicKeyPEM generates a new RSA key pair and returns the public key
+// as a PEM-encoded PKIX string, for Snowflake workspace keypair login in tests.
+func GenerateRSAPublicKeyPEM(t *testing.T) string {
 	t.Helper()
 
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "Failed to generate RSA private key")
 
-	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
-	})
-
 	publicKeyPKIX, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
 	require.NoError(t, err, "Failed to marshal public key to PKIX")
 
-	publicKeyPEM := pem.EncodeToMemory(&pem.Block{
+	return string(pem.EncodeToMemory(&pem.Block{
 		Type:  "PUBLIC KEY",
 		Bytes: publicKeyPKIX,
-	})
-
-	return &RSAKeyPair{
-		PrivateKeyPEM: privateKeyPEM,
-		PublicKeyPEM:  publicKeyPEM,
-		PrivateKey:    privateKey,
-		PublicKey:     &privateKey.PublicKey,
-	}
+	}))
 }
 
 func APIClientForRandomProject(t *testing.T, ctx context.Context, opts ...testproject.Option) (*testproject.Project, *AuthorizedAPI) {

--- a/pkg/keboola/test.go
+++ b/pkg/keboola/test.go
@@ -2,13 +2,56 @@ package keboola
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 	"time"
 
 	"github.com/keboola/go-utils/pkg/testproject"
+	"github.com/stretchr/testify/require"
 
 	"github.com/keboola/keboola-sdk-go/v2/pkg/client"
 )
+
+// RSAKeyPair holds a generated RSA key pair in both PEM-encoded and raw form.
+type RSAKeyPair struct {
+	PrivateKeyPEM []byte
+	PublicKeyPEM  []byte
+	PrivateKey    *rsa.PrivateKey
+	PublicKey     *rsa.PublicKey
+}
+
+// GenerateRSAKeyPairPKCS1 creates a new RSA key pair and returns the private key in PKCS1 format.
+// This is useful for compatibility with systems that expect PKCS1 format (like some Snowflake configurations).
+// Returns both PEM-encoded keys and the raw key objects.
+func GenerateRSAKeyPairPKCS1(t *testing.T) *RSAKeyPair {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "Failed to generate RSA private key")
+
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	publicKeyPKIX, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+	require.NoError(t, err, "Failed to marshal public key to PKIX")
+
+	publicKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: publicKeyPKIX,
+	})
+
+	return &RSAKeyPair{
+		PrivateKeyPEM: privateKeyPEM,
+		PublicKeyPEM:  publicKeyPEM,
+		PrivateKey:    privateKey,
+		PublicKey:     &privateKey.PublicKey,
+	}
+}
 
 func APIClientForRandomProject(t *testing.T, ctx context.Context, opts ...testproject.Option) (*testproject.Project, *AuthorizedAPI) {
 	t.Helper()

--- a/v2/transfer/storage_workspace_export_test.go
+++ b/v2/transfer/storage_workspace_export_test.go
@@ -54,7 +54,7 @@ func TestWorkspaceTableExportSuccess(t *testing.T) {
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
+		PublicKey:     new(keboola.GenerateRSAPublicKeyPEM(t)),
 	}
 
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)
@@ -152,7 +152,7 @@ func TestWorkspaceTableExportGzip(t *testing.T) {
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
+		PublicKey:     new(keboola.GenerateRSAPublicKeyPEM(t)),
 	}
 
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)

--- a/v2/transfer/storage_workspace_export_test.go
+++ b/v2/transfer/storage_workspace_export_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -56,7 +55,7 @@ func TestWorkspaceTableExportSuccess(t *testing.T) {
 		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
+		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
 	}
 
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)
@@ -156,7 +155,7 @@ func TestWorkspaceTableExportGzip(t *testing.T) {
 		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
+		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
 	}
 
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)

--- a/v2/transfer/storage_workspace_export_test.go
+++ b/v2/transfer/storage_workspace_export_test.go
@@ -52,7 +52,6 @@ func TestWorkspaceTableExportSuccess(t *testing.T) {
 	networkPolicy := "user"
 	workspace := &keboola.StorageWorkspacePayload{
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
-		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
 		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
@@ -70,7 +69,6 @@ func TestWorkspaceTableExportSuccess(t *testing.T) {
 	})
 
 	assert.Equal(t, keboola.StorageWorkspaceBackendSnowflake, createdWorkspace.StorageWorkspaceDetails.Backend)
-	assert.Equal(t, keboola.StorageWorkspaceBackendSizeMedium, *createdWorkspace.BackendSize)
 	assert.Equal(t, string(keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair), *createdWorkspace.StorageWorkspaceDetails.LoginType)
 
 	// Load data into workspace
@@ -152,7 +150,6 @@ func TestWorkspaceTableExportGzip(t *testing.T) {
 	networkPolicy := "user"
 	workspace := &keboola.StorageWorkspacePayload{
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
-		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
 		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),

--- a/v2/transfer/storage_workspaces_test.go
+++ b/v2/transfer/storage_workspaces_test.go
@@ -50,7 +50,6 @@ func TestStorageWorkspaceLoadData(t *testing.T) {
 	networkPolicy := "user"
 	workspace := &keboola.StorageWorkspacePayload{
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
-		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
 		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),

--- a/v2/transfer/storage_workspaces_test.go
+++ b/v2/transfer/storage_workspaces_test.go
@@ -3,7 +3,6 @@ package transfer_test
 import (
 	"bytes"
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -54,7 +53,7 @@ func TestStorageWorkspaceLoadData(t *testing.T) {
 		BackendSize:   new(keboola.StorageWorkspaceBackendSizeMedium),
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(os.Getenv("TEST_SNOWFLAKE_PUBLIC_KEY")), //nolint: forbidigo
+		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
 	}
 
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)

--- a/v2/transfer/storage_workspaces_test.go
+++ b/v2/transfer/storage_workspaces_test.go
@@ -52,7 +52,7 @@ func TestStorageWorkspaceLoadData(t *testing.T) {
 		Backend:       keboola.StorageWorkspaceBackendSnowflake,
 		NetworkPolicy: &networkPolicy,
 		LoginType:     keboola.StorageWorkspaceLoginTypeSnowflakeServiceKeypair,
-		PublicKey:     new(string(keboola.GenerateRSAKeyPairPKCS1(t).PublicKeyPEM)),
+		PublicKey:     new(keboola.GenerateRSAPublicKeyPEM(t)),
 	}
 
 	createdWorkspace, err := api.StorageWorkspaceCreateRequest(defBranch.ID, workspace).Send(ctx)


### PR DESCRIPTION
**Changes:**
- Added `keboola.GenerateRSAPublicKeyPEM(t)` test helper that generates a fresh 2048-bit RSA keypair and returns the PKIX public key as a PEM string
- All Snowflake workspace tests now use `StorageWorkspaceLoginTypeSnowflakeServiceKeypair` with a generated public key instead of reading `TEST_SNOWFLAKE_PUBLIC_KEY` from the environment — Snowflake no longer allows the default legacy service login type on migrated projects
- Workspace tests no longer send a `backendSize` override (dynamic backends are not supported); it remains only in the negative `TestStorageWorkspacesCreateWrongBigQuery` test, where the invalid override is the point
- Removed the now-unused `TEST_SNOWFLAKE_PUBLIC_KEY` env from the push workflow (the secret itself stays)
- Fixed a trailing comma in `build/ci/projects.json` that made the file invalid JSON

-----------

🤖 Generated with [Claude Code](https://claude.com/claude-code)