### PR TITLE
fix(management): harden ServiceAccount token read against kubelet rotation [PAT-1979]

### DIFF
--- a/pkg/keboola/management/auth.go
+++ b/pkg/keboola/management/auth.go
@@ -3,14 +3,29 @@
 package management
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
 )
 
 // DefaultServiceAccountTokenPath is the projected Kubernetes ServiceAccount
 // token mounted by the kbc-stacks chart.
 const DefaultServiceAccountTokenPath = "/var/run/secrets/connection.keboola.com/serviceaccount/token" //nolint:gosec // file path, not a credential
+
+// Bounds of the retry that covers a token read racing with a kubelet rotation,
+// see KeboolaServiceAccountAuth.readToken. With the defaults the delays are
+// 20, 40 and 80 ms, so a read failure is reported after 140 ms at the latest.
+const (
+	defaultTokenReadTries     = 4
+	defaultTokenReadBaseDelay = 20 * time.Millisecond
+	maxTokenReadDelay         = 250 * time.Millisecond
+)
 
 // Auth resolves the authentication headers to attach to a Manage API request.
 // AuthHeaders is called per request so file-backed strategies (e.g. a projected
@@ -47,6 +62,13 @@ func (a *ManageAPITokenAuth) AuthHeaders() (map[string]string, error) {
 // kubelet-rotated tokens are picked up automatically.
 type KeboolaServiceAccountAuth struct {
 	tokenPath string
+	// maxTries and baseDelay bound the retry of a transient read, zero values
+	// mean the defaults above. onRetry observes each retry. All three are
+	// unexported: no caller has asked to tune the retry, and keeping them
+	// internal leaves the retry an implementation detail. Tests set them.
+	maxTries  uint
+	baseDelay time.Duration
+	onRetry   backoff.Notify
 }
 
 // NewKeboolaServiceAccountAuth creates a KeboolaServiceAccountAuth reading from tokenPath.
@@ -60,17 +82,88 @@ func NewKeboolaServiceAccountAuth(tokenPath string) *KeboolaServiceAccountAuth {
 }
 
 func (a *KeboolaServiceAccountAuth) AuthHeaders() (map[string]string, error) {
+	token, err := a.readToken()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{HeaderKubernetesAuthorization: "Bearer " + token}, nil
+}
+
+// readToken reads the token file, retrying a read that is missing or empty.
+//
+// The kubelet rotates a projected token by writing a new timestamped directory,
+// atomically swapping the "..data" symlink the token path resolves through, and
+// then removing the old directory. A read whose path resolution interleaves with
+// that removal fails with ENOENT even though the token is there before and after,
+// so a short bounded backoff turns that race into a slightly slower request
+// instead of a failed one.
+//
+// Anything else - no permission, path is a directory - is a real
+// misconfiguration that is not going to fix itself, so readTokenOnce marks it
+// backoff.Permanent and it fails without spending the backoff.
+//
+// This mirrors KeboolaServiceAccountAuthenticator in php-api-client-base, with
+// one deliberate difference: PHP fails fast on an unreadable file and retries an
+// empty read, because there the race surfaces through the process-global stat
+// cache. Go has no stat cache and os.ReadFile is a single open(2), so here the
+// race surfaces as ENOENT and that is what has to be retried. The PHP budget
+// (~1.2 s) covers a cached stat that can persist for a whole request; a window
+// of one syscall needs far less.
+func (a *KeboolaServiceAccountAuth) readToken() (string, error) {
+	tries := a.maxTries
+	if tries < 1 {
+		tries = defaultTokenReadTries
+	}
+
+	// Auth.AuthHeaders takes no context, and the retry is bounded by the tries
+	// and the delays above, so a background context is enough here.
+	return backoff.Retry(
+		context.Background(),
+		a.readTokenOnce,
+		backoff.WithBackOff(a.newBackOff()),
+		backoff.WithMaxTries(tries),
+		backoff.WithNotify(a.onRetry),
+	)
+}
+
+// readTokenOnce is a single attempt of readToken.
+func (a *KeboolaServiceAccountAuth) readTokenOnce() (string, error) {
 	data, err := os.ReadFile(a.tokenPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read service account token file %q: %w", a.tokenPath, err)
+		err = fmt.Errorf("failed to read service account token file %q: %w", a.tokenPath, err)
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", err
+		}
+
+		return "", backoff.Permanent(err)
 	}
 
 	token := strings.TrimSpace(string(data))
 	if token == "" {
-		return nil, fmt.Errorf("service account token file is empty: %q", a.tokenPath)
+		return "", fmt.Errorf("service account token file is empty: %q", a.tokenPath)
 	}
 
-	return map[string]string{HeaderKubernetesAuthorization: "Bearer " + token}, nil
+	return token, nil
+}
+
+// newBackOff returns the delays between the token reads: doubling from baseDelay,
+// capped at maxTokenReadDelay, without jitter - the same shape as
+// RetryConfig.NewBackoff in pkg/request.
+func (a *KeboolaServiceAccountAuth) newBackOff() backoff.BackOff {
+	base := a.baseDelay
+	if base <= 0 {
+		base = defaultTokenReadBaseDelay
+	}
+
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = base
+	b.MaxInterval = maxTokenReadDelay
+	b.Multiplier = 2
+	b.RandomizationFactor = 0
+	b.Reset()
+
+	return b
 }
 
 // NewAutoAuth selects an Auth strategy automatically: a non-empty token yields

--- a/pkg/keboola/management/auth_test.go
+++ b/pkg/keboola/management/auth_test.go
@@ -1,0 +1,137 @@
+package management
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// retryRecorder records the backoff delay of each retry, and runs an optional
+// action to simulate the kubelet finishing a rotation between two reads.
+type retryRecorder struct {
+	delays []time.Duration
+	onCall func(call int)
+}
+
+func (v *retryRecorder) notify(_ error, delay time.Duration) {
+	v.delays = append(v.delays, delay)
+	if v.onCall != nil {
+		v.onCall(len(v.delays))
+	}
+}
+
+// newTestAuth returns an auth with the retry delays shortened, so a test that
+// exercises the retry does not wait for the production backoff.
+func newTestAuth(tokenPath string, recorder *retryRecorder) *KeboolaServiceAccountAuth {
+	return &KeboolaServiceAccountAuth{
+		tokenPath: tokenPath,
+		baseDelay: time.Millisecond,
+		onRetry:   recorder.notify,
+	}
+}
+
+func TestKeboolaServiceAccountAuth_RetriesMissingFile(t *testing.T) {
+	t.Parallel()
+
+	// The token path resolution can hit ENOENT while the kubelet swaps the
+	// "..data" symlink, even though the token is there before and after.
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	recorder := &retryRecorder{onCall: func(call int) {
+		if call == 2 {
+			require.NoError(t, os.WriteFile(tokenPath, []byte("rotated-token\n"), 0o600))
+		}
+	}}
+
+	headers, err := newTestAuth(tokenPath, recorder).AuthHeaders()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{HeaderKubernetesAuthorization: "Bearer rotated-token"}, headers)
+	assert.Len(t, recorder.delays, 2)
+}
+
+func TestKeboolaServiceAccountAuth_RetriesEmptyFile(t *testing.T) {
+	t.Parallel()
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("  \n"), 0o600))
+	recorder := &retryRecorder{onCall: func(int) {
+		require.NoError(t, os.WriteFile(tokenPath, []byte("late-token"), 0o600))
+	}}
+
+	headers, err := newTestAuth(tokenPath, recorder).AuthHeaders()
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer late-token", headers[HeaderKubernetesAuthorization])
+	assert.Len(t, recorder.delays, 1)
+}
+
+func TestKeboolaServiceAccountAuth_GivesUpAfterMaxTries(t *testing.T) {
+	t.Parallel()
+
+	tokenPath := filepath.Join(t.TempDir(), "missing")
+	recorder := &retryRecorder{}
+
+	_, err := newTestAuth(tokenPath, recorder).AuthHeaders()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to read service account token file")
+	assert.ErrorContains(t, err, tokenPath)
+
+	// The default budget is 4 reads, so 3 retries.
+	assert.Len(t, recorder.delays, defaultTokenReadTries-1)
+}
+
+// TestKeboolaServiceAccountAuth_NoRetryOnPermanentError checks that a real
+// misconfiguration fails immediately - a wrong path or wrong permissions is not
+// going to fix itself, and a proxy must not spend the backoff on every request.
+func TestKeboolaServiceAccountAuth_NoRetryOnPermanentError(t *testing.T) {
+	t.Parallel()
+
+	// A directory instead of a file fails with EISDIR on read, regardless of the
+	// user the tests run as.
+	recorder := &retryRecorder{}
+
+	_, err := newTestAuth(t.TempDir(), recorder).AuthHeaders()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to read service account token file")
+	assert.Empty(t, recorder.delays)
+}
+
+// TestKeboolaServiceAccountAuth_BackOffDelays checks the production delays, which
+// the tests above shorten. The sequence doubles and is capped, so the default
+// budget of 4 reads spends at most 20+40+80 = 140 ms.
+func TestKeboolaServiceAccountAuth_BackOffDelays(t *testing.T) {
+	t.Parallel()
+
+	b := NewKeboolaServiceAccountAuth("/token").newBackOff()
+
+	var delays []time.Duration
+	for range 6 {
+		delays = append(delays, b.NextBackOff())
+	}
+
+	assert.Equal(t, []time.Duration{
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		80 * time.Millisecond,
+		160 * time.Millisecond,
+		maxTokenReadDelay,
+		maxTokenReadDelay,
+	}, delays)
+}
+
+// TestKeboolaServiceAccountAuth_ReadsTokenOnFirstAttempt checks the common case:
+// a readable token costs a single read and no backoff.
+func TestKeboolaServiceAccountAuth_ReadsTokenOnFirstAttempt(t *testing.T) {
+	t.Parallel()
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("k8s-token\n"), 0o600))
+	recorder := &retryRecorder{}
+
+	headers, err := newTestAuth(tokenPath, recorder).AuthHeaders()
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer k8s-token", headers[HeaderKubernetesAuthorization])
+	assert.Empty(t, recorder.delays)
+}


### PR DESCRIPTION
## Release Notes
https://linear.app/keboola/issue/PAT-1979/switch-apps-proxy-from-application-token

> [!NOTE]
> Hardening nacitani SA tokenu podle toho, jak to mame v PHP klientech - pridany osetreni race-condition, kdyz se sejde cteni file presne s rotaci tokenu. Sance je malinkata, ale uz jsme se s tim historicky parkrat setkali.

`KeboolaServiceAccountAuth` read the projected Kubernetes ServiceAccount token with a single `os.ReadFile` and turned any failure into a request error. The kubelet rotates a projected token by writing a new timestamped directory, atomically swapping the `..data` symlink the token path resolves through, and then removing the old directory — a read whose path resolution interleaves with that removal fails with `ENOENT` even though the token is present both before and after. `AuthHeaders` is called per request, so that race surfaces as a failed API call rather than a slightly slower one.

The read now goes through `backoff.Retry` (`cenkalti/backoff/v5`, already a direct dependency) with the same `ExponentialBackOff` shape `pkg/request`'s `RetryConfig.NewBackoff` uses — doubling, capped, no jitter: 4 reads, 20/40/80 ms, 140 ms worst case. A missing or empty read is retried; anything else — no permission, path is a directory — is marked `backoff.Permanent`, so a genuinely broken mount fails immediately instead of paying the backoff on every request. Why the retry belongs here and not in an HTTP retry layer: the generated `management` client has none, and in consumers such as `apps-proxy` the error is raised while *building* the request, before `Send()`, so no HTTP retry would ever see it.

This is the Go counterpart of `KeboolaServiceAccountAuthenticator` in `php-api-client-base`, with one deliberate difference documented on `readToken`: PHP fails fast on an unreadable file and retries an *empty* read, because there the race surfaces through the process-global stat cache (hence also `clearstatcache()` and its ~1.2 s budget). Go has no stat cache and `os.ReadFile` is a single `open(2)`, so here the race surfaces as `ENOENT` — that is what has to be retried, and a one-syscall window needs a far smaller budget. The retry bounds are unexported: no caller has asked to tune them, so the retry stays an implementation detail (tests shorten the delays and observe the retries through `backoff.Notify`).

* Spin-off of the `apps-proxy` switch from `APPLICATION_TOKEN` to ServiceAccount auth in `keboola-as-code`. That change works against the current `v2.21.0` and does **not** depend on this PR; picking the retry up there is a later `go.mod` bump once this is tagged.
* Verified with `task lint` (both modules) and `go test -race ./pkg/request/... ./pkg/client/... ./pkg/keboola/management/...`. The project-backed integration tests were not run — they need live Keboola project tokens.

## Plans for customer communication
None.

## Impact analysis
No end-user impact — no consumer is on this commit yet. Once a consumer bumps, a broken token mount costs up to 140 ms per read attempt instead of failing instantly; in `apps-proxy` that backoff runs inside the per-app config-refresh lock, so same-app requests queue behind it for that long. Bounded, well inside the existing 30 s refresh timeout, and only when the mount is actually broken.

## Change type
Improvement

## Justification
Parity with `KeboolaServiceAccountAuthenticator` in `php-api-client-base`, which was hardened against the same rotation race.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.
